### PR TITLE
Refactor user profile and nickname APIs, convert enums to strings, an…

### DIFF
--- a/src/main/java/com/puzzlelog/api/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/puzzlelog/api/config/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.puzzlelog.api.config;
 
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -11,11 +9,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<Void>> handleRuntimeException(RuntimeException e) {
+    	e.printStackTrace(); // 확인 로그
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.fail(e.getMessage()));

--- a/src/main/java/com/puzzlelog/api/dao/document/Piece.java
+++ b/src/main/java/com/puzzlelog/api/dao/document/Piece.java
@@ -27,8 +27,9 @@ public class Piece {
 
     private String userId; // MySQL users 테이블의 user_id 참조
 
-    private Type type;  // 조각 유형 (text, image, video, audio)
-    
+    @Builder.Default
+    private String type = "TEXT";  // TEXT, IMAGE, VIDEO, AUDIO
+
     private String content;  // 조각 내용 (텍스트 형식일 때 사용)
 
     private List<String> tags;  // 태그 정보 (배열)
@@ -36,19 +37,15 @@ public class Piece {
     private GeoJsonPoint location;  // 위치 정보
 
     private String mediaId;
-    
+
     private String publicId;  // ✅ Cloudinary publicId 추가
 
     @Builder.Default
     private Boolean isPrivate = false;
-    
+
     @CreatedDate
     private Instant createdAt; // 자동 시간 저장
 
     @Builder.Default
     private Boolean isDeleted = false;
-
-    public enum Type {
-        TEXT, IMAGE, VIDEO, AUDIO
-    }
 }

--- a/src/main/java/com/puzzlelog/api/dao/entity/Friend.java
+++ b/src/main/java/com/puzzlelog/api/dao/entity/Friend.java
@@ -13,7 +13,8 @@ import java.time.LocalDateTime;
 @Table(name = "friend",
        indexes = {
            @Index(name = "user_id_index", columnList = "user_id"),
-           @Index(name = "friend_id_index", columnList = "friend_id")
+           @Index(name = "friend_id_index", columnList = "friend_id"),
+           @Index(name = "status_index", columnList = "status")
        })
 public class Friend {
 
@@ -29,10 +30,9 @@ public class Friend {
     @JoinColumn(name = "friend_id", referencedColumnName = "user_id", nullable = false)
     private User friend;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", nullable = false, length = 20)
     @Builder.Default
-    private Status status = Status.PENDING;
+    private String status = "PENDING";  // PENDING, ACCEPTED, DEACTIVATED, BLOCKED, REJECTED
 
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -44,14 +44,13 @@ public class Friend {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
+        if (status == null) {
+            status = "PENDING";
+        }
     }
 
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
-    }
-
-    public enum Status {
-        PENDING, ACCEPTED, DEACTIVATED, BLOCKED, REJECTED
     }
 }

--- a/src/main/java/com/puzzlelog/api/dao/entity/User.java
+++ b/src/main/java/com/puzzlelog/api/dao/entity/User.java
@@ -6,8 +6,6 @@ import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -58,9 +56,8 @@ public class User implements Serializable {
     @Column(name = "birth_date")
     private LocalDate birthDate;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "gender")
-    private Gender gender;
+    @Column(name = "gender", length = 10)
+    private String gender; // "MALE", "FEMALE"
 
     @Column(name = "nickname", length = 50)
     private String nickname;
@@ -82,17 +79,15 @@ public class User implements Serializable {
     private LocalDateTime updatedAt;
 
     @Builder.Default
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status")
-    private Status status = Status.ACTIVE;
+    @Column(name = "status", length = 20)
+    private String status = "ACTIVE"; // "ACTIVE", "DELETED", "BANNED"
 
     @Column(name = "last_login")
     private LocalDateTime lastLogin;
 
     @Builder.Default
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role")
-    private Role role = Role.USER;
+    @Column(name = "role", length = 20)
+    private String role = "USER"; //  "USER", "ADMIN"
 
     @PrePersist
     protected void onCreate() {
@@ -100,24 +95,12 @@ public class User implements Serializable {
         updatedAt = LocalDateTime.now();
         
         if (isAlarm == null) isAlarm = true;
-        if (status == null) status = Status.ACTIVE;
-        if (role == null) role = Role.USER;
+        if (status == null) status = "ACTIVE";
+        if (role == null) role = "USER";
     }
 
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
-    }
-
-    public enum Gender {
-        MALE, FEMALE
-    }
-
-    public enum Status {
-        ACTIVE, DELETED, BANNED
-    }
-
-    public enum Role {
-        USER, ADMIN
     }
 }

--- a/src/main/java/com/puzzlelog/api/dto/request/piece/PieceRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/piece/PieceRequest.java
@@ -6,8 +6,6 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 
-import com.puzzlelog.api.dao.document.Piece.Type;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +23,7 @@ public class PieceRequest {
     private String userId;
 
     @NotNull(message = "타입은 필수입니다.")
-    private Type type;
+    private String type; // TEXT, IMAGE, VIDEO, AUDIO
 
     private String content;  // Type이 TEXT일 때 필수
     

--- a/src/main/java/com/puzzlelog/api/dto/request/piece/PieceSearchRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/piece/PieceSearchRequest.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.puzzlelog.api.dao.document.Piece.Type;
-
 import lombok.*;
 
 @Getter
@@ -16,7 +14,7 @@ import lombok.*;
 @Builder
 public class PieceSearchRequest {
     private String userId;
-    private Type type;
+    private String type;  // TEXT, IMAGE, VIDEO, AUDIO
     private String content;          // LIKE 검색을 위한 키워드
     private List<String> tags;       // 태그 검색 (태그 중 하나라도 포함)
 

--- a/src/main/java/com/puzzlelog/api/dto/request/piece/PieceUpdateRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/piece/PieceUpdateRequest.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 
-import com.puzzlelog.api.dao.document.Piece.Type;
-
 import lombok.*;
 
 @Getter
@@ -15,7 +13,7 @@ import lombok.*;
 @Builder
 public class PieceUpdateRequest {
 
-    private Type type; // 변경될 수 있음 (선택적)
+    private String type; // "TEXT", "IMAGE", "VIDEO", "AUDIO"
 
     private String content; // TEXT 타입 시 필수
 

--- a/src/main/java/com/puzzlelog/api/dto/request/user/UserSearchRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/user/UserSearchRequest.java
@@ -4,10 +4,6 @@ import java.time.LocalDate;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.puzzlelog.api.dao.entity.User.Gender;
-import com.puzzlelog.api.dao.entity.User.Role;
-import com.puzzlelog.api.dao.entity.User.Status;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,24 +17,26 @@ public class UserSearchRequest {
     private String email;
     private String userId;
     private String nickname;
-    private Gender gender;
+    private String gender;  // "MALE", "FEMALE"
     private Boolean isAlarm;
-    private Status status;
-    private Role role;
+    private String status;  // "ACTIVE", "DELETED", "BANNED"
+    private String role;    // "USER", "ADMIN"
     
-    // 날짜 형태
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate createdAtFrom;
+    
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate createdAtTo;
     
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate birthDateFrom;
+    
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate birthDateTo;
     
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate lastLoginFrom;
+    
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate lastLoginTo;
     
@@ -57,5 +55,4 @@ public class UserSearchRequest {
                lastLoginFrom == null &&
                lastLoginTo == null;
     }
-
 }

--- a/src/main/java/com/puzzlelog/api/dto/request/user/UserUpdateRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/user/UserUpdateRequest.java
@@ -1,7 +1,11 @@
 package com.puzzlelog.api.dto.request.user;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,28 +13,77 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class UserUpdateRequest {
-    private String userPwd;     // 비밀번호 (기존 비밀번호 확인 별도 로직 필요)
-    private String nickname;    // 닉네임 (중복 체크)
-    private String birthDate;   // 생년월일
-    private String gender;      // 성별 (MALE/FEMALE)
-    private Boolean isAlarm;    // 알림 설정 여부
-    private String profileImg;  // 프로필 이미지 URL
+    private String userPwd;    
+    private String nickname;   
+    private String birthDate;  
+    private String gender;     
+    private Boolean isAlarm;   
+    private String profileImg; 
+    private String status;     
+    private String role;       
 
-    // 관리자 전용 필드
-    private String status;      // ACTIVE, DELETED, BANNED
-    private String role;        // USER, ADMIN
-    
+    @JsonIgnore
+    private final Set<String> fieldsSet = new HashSet<>();
+
+    @JsonSetter("userPwd")
+    public void setUserPwd(String userPwd) {
+        this.userPwd = userPwd;
+        fieldsSet.add("userPwd");
+    }
+
+    @JsonSetter("nickname")
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+        fieldsSet.add("nickname");
+    }
+
+    @JsonSetter("birthDate")
+    public void setBirthDate(String birthDate) {
+        this.birthDate = birthDate;
+        fieldsSet.add("birthDate");
+    }
+
+    @JsonSetter("gender")
+    public void setGender(String gender) {
+        this.gender = gender;
+        fieldsSet.add("gender");
+    }
+
+    @JsonSetter("isAlarm")
+    public void setIsAlarm(Boolean isAlarm) {
+        this.isAlarm = isAlarm;
+        fieldsSet.add("isAlarm");
+    }
+
+    @JsonSetter("profileImg")
+    public void setProfileImg(String profileImg) {
+        this.profileImg = profileImg;
+        fieldsSet.add("profileImg");
+    }
+
+    @JsonSetter("status")
+    public void setStatus(String status) {
+        this.status = status;
+        fieldsSet.add("status");
+    }
+
+    @JsonSetter("role")
+    public void setRole(String role) {
+        this.role = role;
+        fieldsSet.add("role");
+    }
+
+    public boolean hasUserPwd() { return fieldsSet.contains("userPwd"); }
+    public boolean hasNickname() { return fieldsSet.contains("nickname"); }
+    public boolean hasBirthDate() { return fieldsSet.contains("birthDate"); }
+    public boolean hasGender() { return fieldsSet.contains("gender"); }
+    public boolean hasIsAlarm() { return fieldsSet.contains("isAlarm"); }
+    public boolean hasProfileImg() { return fieldsSet.contains("profileImg"); }
+    public boolean hasStatus() { return fieldsSet.contains("status"); }
+    public boolean hasRole() { return fieldsSet.contains("role"); }
+
     public boolean isEmpty() {
-        return userPwd == null &&
-               nickname == null &&
-               birthDate == null &&
-               gender == null &&
-               isAlarm == null &&
-               profileImg == null &&
-               status == null &&
-               role == null;
+        return fieldsSet.isEmpty();
     }
 }

--- a/src/main/java/com/puzzlelog/api/dto/response/piece/PieceResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/piece/PieceResponse.java
@@ -34,7 +34,7 @@ public class PieceResponse {
         return PieceResponse.builder()
                 .id(piece.getId())
                 .userId(piece.getUserId())
-                .type(piece.getType().name())
+                .type(piece.getType())
                 .content(piece.getContent())
                 .tags(piece.getTags())
                 .location(piece.getLocation())

--- a/src/main/java/com/puzzlelog/api/dto/response/user/UserResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/user/UserResponse.java
@@ -17,14 +17,14 @@ public class UserResponse {
     private String email;
     private String nickname;
     private LocalDate birthDate;
-    private User.Gender gender;
+    private String gender; // "MALE", "FEMALE"
     private Boolean isAlarm;
     private String profileImg;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private User.Status status;
+    private String status; // "ACTIVE", "DELETED", "BANNED"
     private LocalDateTime lastLogin;
-    private User.Role role;
+    private String role; // "USER", "ADMIN"
 
     // 엔티티에서 Response DTO로 변환
     public static UserResponse from(User user) {

--- a/src/main/java/com/puzzlelog/api/repository/mysql/FriendRepository.java
+++ b/src/main/java/com/puzzlelog/api/repository/mysql/FriendRepository.java
@@ -12,7 +12,7 @@ import com.puzzlelog.api.dao.entity.Friend;
 public interface FriendRepository extends JpaRepository<Friend, Integer> {
 
     // 특정 상태의 친구 관계 존재 여부 확인 (PENDING, ACCEPTED 등)
-    boolean existsByUser_UserIdAndFriend_UserIdAndStatusIn(String userId, String friendId, Friend.Status... statuses);
+    boolean existsByUser_UserIdAndFriend_UserIdAndStatusIn(String userId, String friendId, String... statuses);
 
     // 특정 친구 관계 조회 (중복까지 방지)
     List<Friend> findAllByUser_UserIdAndFriend_UserId(String userId, String friendId);
@@ -21,14 +21,14 @@ public interface FriendRepository extends JpaRepository<Friend, Integer> {
     Optional<Friend> findFirstByUser_UserIdAndFriend_UserIdOrderByCreatedAtDesc(String userId, String friendId);
 
     // 친구 요청 받은 목록 조회 (상태가 PENDING이며 friendId가 특정 사용자)
-    List<Friend> findAllByFriend_UserIdAndStatus(String friendId, Friend.Status status);
+    List<Friend> findAllByFriend_UserIdAndStatus(String friendId, String status);
 
     // 친구 요청 보낸 목록 조회 (상태가 PENDING이며 userId가 특정 사용자)
-    List<Friend> findAllByUser_UserIdAndStatus(String userId, Friend.Status status);
+    List<Friend> findAllByUser_UserIdAndStatus(String userId, String status);
 
     // 내가 받은 친구 요청 (상태가 PENDING)
-    Page<Friend> findByFriend_UserIdAndStatus(String friendId, Friend.Status status, Pageable pageable);
+    Page<Friend> findByFriend_UserIdAndStatus(String friendId, String status, Pageable pageable);
 
     // 내가 보낸 친구 요청 (상태가 PENDING), 친구 상태 ACCEPTED 조회
-    Page<Friend> findByUser_UserIdAndStatus(String userId, Friend.Status status, Pageable pageable);
+    Page<Friend> findByUser_UserIdAndStatus(String userId, String status, Pageable pageable);
 }

--- a/src/main/java/com/puzzlelog/api/repository/mysql/UserRepository.java
+++ b/src/main/java/com/puzzlelog/api/repository/mysql/UserRepository.java
@@ -1,61 +1,18 @@
 package com.puzzlelog.api.repository.mysql;
 
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import com.puzzlelog.api.dao.entity.User;
-import com.puzzlelog.api.dto.request.user.UserSearchRequest;
 
-public interface UserRepository extends JpaRepository<User, Integer> {
-    
-	Optional<User> findByUserId(String userId);
+public interface UserRepository extends JpaRepository<User, Integer>, JpaSpecificationExecutor<User> {
+    Optional<User> findByUserId(String userId);
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
-    
-    // 로그인 및 중복체크 시 사용
+
     boolean existsByUserId(String userId);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
-    
-    // 조회 사용 (SELECT 땐 JAVA 쓰는 것이 낫다.)
-    @Query("SELECT u FROM User u WHERE "
-            + "(:#{#req.email} IS NULL OR u.email = :#{#req.email}) AND "
-            + "(:#{#req.userId} IS NULL OR u.userId = :#{#req.userId}) AND "
-            + "(:#{#req.nickname} IS NULL OR u.nickname = :#{#req.nickname}) AND "
-            + "(:#{#req.createdAtFrom} IS NULL OR u.createdAt >= :createdAtFrom) AND "
-            + "(:#{#req.createdAtTo} IS NULL OR u.createdAt <= :createdAtTo) AND "
-            + "(:#{#req.birthDateFrom} IS NULL OR u.birthDate >= :#{#req.birthDateFrom}) AND "
-            + "(:#{#req.birthDateTo} IS NULL OR u.birthDate <= :#{#req.birthDateTo}) AND "
-            + "(:#{#req.gender} IS NULL OR u.gender = :#{#req.gender}) AND "
-            + "(:#{#req.isAlarm} IS NULL OR u.isAlarm = :#{#req.isAlarm}) AND "
-            + "(:#{#req.status} IS NULL OR u.status = :#{#req.status}) AND "
-            + "(:#{#req.role} IS NULL OR u.role = :#{#req.role}) AND "
-            + "(:#{#req.lastLoginFrom} IS NULL OR u.lastLogin >= :lastLoginFrom) AND "
-            + "(:#{#req.lastLoginTo} IS NULL OR u.lastLogin <= :lastLoginTo)")
-        Page<User> findUsersByConditions(
-            @Param("req") UserSearchRequest req,
-            @Param("createdAtFrom") LocalDateTime createdAtFrom,
-            @Param("createdAtTo") LocalDateTime createdAtTo,
-            @Param("lastLoginFrom") LocalDateTime lastLoginFrom,
-            @Param("lastLoginTo") LocalDateTime lastLoginTo,
-            Pageable pageable);
-
-        default Page<User> searchUsers(UserSearchRequest req, Pageable pageable) {
-            return findUsersByConditions(
-                req,
-                req.getCreatedAtFrom() != null ? req.getCreatedAtFrom().atStartOfDay() : null,
-                req.getCreatedAtTo() != null ? req.getCreatedAtTo().atTime(LocalTime.MAX) : null,
-                req.getLastLoginFrom() != null ? req.getLastLoginFrom().atStartOfDay() : null,
-                req.getLastLoginTo() != null ? req.getLastLoginTo().atTime(LocalTime.MAX) : null,
-                pageable
-            );
-        }
-
 }

--- a/src/main/java/com/puzzlelog/api/repository/mysql/UserSpecifications.java
+++ b/src/main/java/com/puzzlelog/api/repository/mysql/UserSpecifications.java
@@ -1,0 +1,81 @@
+package com.puzzlelog.api.repository.mysql;
+
+import com.puzzlelog.api.dao.entity.User;
+import com.puzzlelog.api.dto.request.user.UserSearchRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public class UserSpecifications {
+
+    // 조건별 동적 쿼리 생성 (Specification 조합)
+    public static Specification<User> withConditions(UserSearchRequest req) {
+        return Specification
+            .where(emailEquals(req.getEmail()))
+            .and(userIdEquals(req.getUserId()))
+            .and(nicknameEquals(req.getNickname()))
+            .and(createdAtBetween(req.getCreatedAtFrom(), req.getCreatedAtTo()))
+            .and(birthDateBetween(req.getBirthDateFrom(), req.getBirthDateTo()))
+            .and(genderEquals(req.getGender()))
+            .and(isAlarmEquals(req.getIsAlarm()))
+            .and(statusEquals(req.getStatus()))
+            .and(roleEquals(req.getRole()))
+            .and(lastLoginBetween(req.getLastLoginFrom(), req.getLastLoginTo()));
+    }
+
+    private static Specification<User> emailEquals(String email) {
+        return (root, query, cb) -> email == null ? null : cb.equal(root.get("email"), email);
+    }
+
+    private static Specification<User> userIdEquals(String userId) {
+        return (root, query, cb) -> userId == null ? null : cb.equal(root.get("userId"), userId);
+    }
+
+    private static Specification<User> nicknameEquals(String nickname) {
+        return (root, query, cb) -> nickname == null ? null : cb.equal(root.get("nickname"), nickname);
+    }
+
+    // 생성일자 범위로 조회
+    private static Specification<User> createdAtBetween(LocalDate from, LocalDate to) {
+        if (from == null && to == null) return null;
+
+        LocalDateTime fromDate = from != null ? from.atStartOfDay() : LocalDateTime.MIN;
+        LocalDateTime toDate = to != null ? to.atTime(LocalTime.MAX) : LocalDateTime.MAX;
+
+        return (root, query, cb) -> cb.between(root.get("createdAt"), fromDate, toDate);
+    }
+
+    // 생년월일 범위로 조회
+    private static Specification<User> birthDateBetween(LocalDate from, LocalDate to) {
+        if (from == null && to == null) return null;
+        return (root, query, cb) -> cb.between(root.get("birthDate"), from, to);
+    }
+
+    private static Specification<User> genderEquals(String gender) {
+        return (root, query, cb) -> gender == null ? null : cb.equal(root.get("gender"), gender);
+    }
+
+    private static Specification<User> isAlarmEquals(Boolean isAlarm) {
+        return (root, query, cb) -> isAlarm == null ? null : cb.equal(root.get("isAlarm"), isAlarm);
+    }
+
+    private static Specification<User> statusEquals(String status) {
+        return (root, query, cb) -> status == null ? null : cb.equal(root.get("status"), status);
+    }
+
+    private static Specification<User> roleEquals(String role) {
+        return (root, query, cb) -> role == null ? null : cb.equal(root.get("role"), role);
+    }
+
+    // 마지막 로그인 범위로 조회
+    private static Specification<User> lastLoginBetween(LocalDate from, LocalDate to) {
+        if (from == null && to == null) return null;
+
+        LocalDateTime fromDate = from != null ? from.atStartOfDay() : LocalDateTime.MIN;
+        LocalDateTime toDate = to != null ? to.atTime(LocalTime.MAX) : LocalDateTime.MAX;
+
+        return (root, query, cb) -> cb.between(root.get("lastLogin"), fromDate, toDate);
+    }
+}

--- a/src/main/java/com/puzzlelog/api/service/AuthService.java
+++ b/src/main/java/com/puzzlelog/api/service/AuthService.java
@@ -62,7 +62,7 @@ public class AuthService { // 인증 기능
                 .userPwd(passwordEncoder.encode(request.getUserPwd()))
                 .email(request.getEmail())
                 .birthDate(request.getBirthDate() != null ? LocalDate.parse(request.getBirthDate()) : null)
-                .gender(request.getGender() != null ? User.Gender.valueOf(request.getGender()) : null)
+                .gender(request.getGender())
                 .profileImg(profileImgUrl)
                 .build();
 
@@ -87,10 +87,10 @@ public class AuthService { // 인증 기능
                 .orElse(null);
     }
     
-    // 관리자 확인
+ // 관리자 확인
     public boolean isAdmin(String userId) {
         return userRepository.findByUserId(userId)
-                .map(user -> user.getRole() == User.Role.ADMIN)
+                .map(user -> "ADMIN".equals(user.getRole()))
                 .orElse(false);
     }
 }

--- a/src/main/java/com/puzzlelog/api/service/FriendService.java
+++ b/src/main/java/com/puzzlelog/api/service/FriendService.java
@@ -36,11 +36,11 @@ public class FriendService {
     	    this.friendHistoryRepository = friendHistoryRepository;
     	}
     
-    // 상태 확인 메소드
+    // 상태 확인 메소드 (null-safe)
     private void validateUserStatus(User user, boolean isRequester) {
-        if (user.getStatus() == User.Status.DELETED) {
+        if ("DELETED".equals(user.getStatus())) {
             throw new RuntimeException(isRequester ? "요청 사용자를 찾을 수 없습니다." : "대상 사용자를 찾을 수 없습니다.");
-        } else if (user.getStatus() == User.Status.BANNED) {
+        } else if ("BANNED".equals(user.getStatus())) {
             throw new RuntimeException(isRequester ? "차단된 사용자는 친구 요청을 보낼 수 없습니다."
                     : "차단된 사용자에게 친구 요청을 보낼 수 없습니다.");
         }
@@ -74,15 +74,15 @@ public class FriendService {
 
         if (existingFriend != null) {
             switch (existingFriend.getStatus()) {
-                case PENDING:
+                case "PENDING":
                     throw new RuntimeException("이미 친구 요청한 상태입니다.");
-                case ACCEPTED:
+                case "ACCEPTED":
                     throw new RuntimeException("이미 친구입니다.");
-                case BLOCKED:
+                case "BLOCKED":
                     throw new RuntimeException("차단된 사용자에게 친구 요청을 보낼 수 없습니다.");
-                case DEACTIVATED:
-                case REJECTED:
-                    existingFriend.setStatus(Friend.Status.PENDING);
+                case "DEACTIVATED":
+                case "REJECTED":
+                    existingFriend.setStatus("PENDING");
                     friend = friendRepository.save(existingFriend);
                     break;
                 default:
@@ -92,7 +92,7 @@ public class FriendService {
             friend = Friend.builder()
                     .user(requester)
                     .friend(receiver)
-                    .status(Friend.Status.PENDING)
+                    .status("PENDING")
                     .build();
 
             friend = friendRepository.save(friend);
@@ -102,7 +102,7 @@ public class FriendService {
         FriendHistory history = FriendHistory.builder()
                 .userId(userId)
                 .friendId(friendId)
-                .status(friend.getStatus().name())
+                .status(friend.getStatus())
                 .timestamp(LocalDateTime.now())
                 .build();
 
@@ -118,17 +118,17 @@ public class FriendService {
                 .findFirstByUser_UserIdAndFriend_UserIdOrderByCreatedAtDesc(friendId, userId)
                 .orElseThrow(() -> new RuntimeException("해당 친구 요청을 찾을 수 없습니다."));
 
-        if (friendRequest.getStatus() != Friend.Status.PENDING) {
+        if (!friendRequest.getStatus().equals("PENDING")) {
             throw new RuntimeException("이미 처리된 친구 요청입니다.");
         }
 
-        friendRequest.setStatus(Friend.Status.ACCEPTED);
+        friendRequest.setStatus("ACCEPTED");
         friendRepository.save(friendRequest);
 
         Friend reciprocalFriend = Friend.builder()
             .user(friendRequest.getFriend())
             .friend(friendRequest.getUser())
-            .status(Friend.Status.ACCEPTED)
+            .status("ACCEPTED")
             .build();
 
         friendRepository.save(reciprocalFriend);
@@ -137,35 +137,35 @@ public class FriendService {
         friendHistoryRepository.save(FriendHistory.builder()
             .userId(userId)              // 요청을 수락한 사람
             .friendId(friendId)          // 친구 요청 보낸 사람
-            .status(Friend.Status.ACCEPTED.name())
+            .status("ACCEPTED")
             .timestamp(LocalDateTime.now())
             .build());
     }
     
-    // 친구 요청 거절
+ // 친구 요청 거절
     @Transactional
     public void rejectFriendRequest(String userId, String friendId) {
         Friend friendRequest = friendRepository
             .findFirstByUser_UserIdAndFriend_UserIdOrderByCreatedAtDesc(friendId, userId)
             .orElseThrow(() -> new RuntimeException("해당 친구 요청을 찾을 수 없습니다."));
 
-        if (friendRequest.getStatus() != Friend.Status.PENDING) {
+        if (!friendRequest.getStatus().equals("PENDING")) {
             throw new RuntimeException("이미 처리된 친구 요청입니다.");
         }
 
-        friendRequest.setStatus(Friend.Status.REJECTED);
+        friendRequest.setStatus("REJECTED");
         friendRepository.save(friendRequest);
 
         // ✅ 친구 요청 거절 기록 MongoDB 저장
         friendHistoryRepository.save(FriendHistory.builder()
             .userId(userId)              // 요청을 거절한 사람
             .friendId(friendId)          // 친구 요청 보낸 사람
-            .status(Friend.Status.REJECTED.name())
+            .status("REJECTED")
             .timestamp(LocalDateTime.now())
             .build());
     }
 
-    // 친구 목록 조회 (페이징, 상태별 조회)
+ // 친구 목록 조회 (페이징, 상태별 조회)
     @Transactional(readOnly = true)
     public PagedFriendResponse getFriendsByType(String userId, String type, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
@@ -174,19 +174,19 @@ public class FriendService {
 
         switch (type.toLowerCase()) {
             case "your_request":  // 나에게 온 친구 요청 (받은 요청)
-                friends = friendRepository.findByFriend_UserIdAndStatus(userId, Friend.Status.PENDING, pageable);
+                friends = friendRepository.findByFriend_UserIdAndStatus(userId, "PENDING", pageable);
                 break;
 
             case "my_request":  // 내가 보낸 친구 요청
-                friends = friendRepository.findByUser_UserIdAndStatus(userId, Friend.Status.PENDING, pageable);
+                friends = friendRepository.findByUser_UserIdAndStatus(userId, "PENDING", pageable);
                 break;
 
             case "friends":  // 친구 상태
-                friends = friendRepository.findByUser_UserIdAndStatus(userId, Friend.Status.ACCEPTED, pageable);
+                friends = friendRepository.findByUser_UserIdAndStatus(userId, "ACCEPTED", pageable);
                 break;
 
             case "blocked":  // 차단된 친구 목록
-                friends = friendRepository.findByUser_UserIdAndStatus(userId, Friend.Status.BLOCKED, pageable);
+                friends = friendRepository.findByUser_UserIdAndStatus(userId, "BLOCKED", pageable);
                 break;
 
             default:
@@ -217,21 +217,21 @@ public class FriendService {
                     .friend(target)
                     .build());
 
-        friend.setStatus(Friend.Status.BLOCKED);
+        friend.setStatus("BLOCKED");
         friendRepository.save(friend);
 
         // MongoDB에 차단 상태 기록 저장
         friendHistoryRepository.save(FriendHistory.builder()
             .userId(userId)
             .friendId(friendId)
-            .status(Friend.Status.BLOCKED.name())
+            .status("BLOCKED")
             .timestamp(LocalDateTime.now())
             .build());
 
         return FriendResponse.from(friend);
     }
 
-    // 친구 차단 해제
+ // 친구 차단 해제
     @Transactional
     public FriendResponse unblockFriend(String userId, String friendId) {
         validateUserStatus(getUserByUserId(userId, true), true);
@@ -241,19 +241,19 @@ public class FriendService {
                 .findFirstByUser_UserIdAndFriend_UserIdOrderByCreatedAtDesc(userId, friendId)
                 .orElseThrow(() -> new RuntimeException("차단된 친구 정보를 찾을 수 없습니다."));
 
-        if (friend.getStatus() != Friend.Status.BLOCKED) {
+        if (!"BLOCKED".equals(friend.getStatus())) {
             throw new RuntimeException("현재 차단 상태가 아닙니다.");
         }
 
         // 차단 해제 시 기존 친구 상태로 복원 (ACCEPTED)
-        friend.setStatus(Friend.Status.ACCEPTED);
+        friend.setStatus("ACCEPTED");
         Friend updatedFriend = friendRepository.save(friend);
 
         // MongoDB에 차단 해제 상태 기록 저장
         friendHistoryRepository.save(FriendHistory.builder()
             .userId(userId)
             .friendId(friendId)
-            .status(Friend.Status.ACCEPTED.name()) // 차단 해제 시 ACCEPTED 상태로 복귀
+            .status("ACCEPTED") // 차단 해제 시 ACCEPTED 상태로 복귀
             .timestamp(LocalDateTime.now())
             .build());
 
@@ -269,16 +269,16 @@ public class FriendService {
         Friend friend = friendRepository.findFirstByUser_UserIdAndFriend_UserIdOrderByCreatedAtDesc(userId, friendId)
                 .orElseThrow(() -> new RuntimeException("친구가 아닙니다."));
 
-        if (friend.getStatus() != Friend.Status.ACCEPTED) {
+        if (!"ACCEPTED".equals(friend.getStatus())) {
             throw new RuntimeException("친구가 아닙니다.");
         }
 
-        friend.setStatus(Friend.Status.DEACTIVATED);
+        friend.setStatus("DEACTIVATED");
         friendRepository.save(friend);
 
         friendRepository.findFirstByUser_UserIdAndFriend_UserIdOrderByCreatedAtDesc(friendId, userId)
                 .ifPresent(reciprocal -> {
-                    reciprocal.setStatus(Friend.Status.DEACTIVATED);
+                    reciprocal.setStatus("DEACTIVATED");
                     friendRepository.save(reciprocal);
                 });
 
@@ -286,7 +286,7 @@ public class FriendService {
         friendHistoryRepository.save(FriendHistory.builder()
             .userId(userId)     // 삭제한 사람
             .friendId(friendId) // 삭제된 상대방
-            .status(Friend.Status.DEACTIVATED.name())
+            .status("DEACTIVATED")
             .timestamp(LocalDateTime.now())
             .build());
 

--- a/src/main/java/com/puzzlelog/api/service/PieceService.java
+++ b/src/main/java/com/puzzlelog/api/service/PieceService.java
@@ -52,35 +52,35 @@ public class PieceService {
     // 조각 추가 메서드 (완전한 형태)
     public PieceResponse addPiece(PieceRequest request, MultipartFile file, String authenticatedUserId) {
         
-        // 인증된 사용자가 본인이 맞는지 검증 (권한 체크)
-        if (!authenticatedUserId.equals(request.getUserId())) {
-            throw new RuntimeException("본인만 조각을 추가할 수 있습니다.");
-        }
+    	// 인증된 사용자가 본인이 맞는지 검증 (권한 체크)
+    	if (!authenticatedUserId.equals(request.getUserId())) {
+    	    throw new RuntimeException("본인만 조각을 추가할 수 있습니다.");
+    	}
 
-        if (request.getUserId() == null || request.getUserId().trim().isEmpty()) {
-            throw new RuntimeException("사용자 ID는 필수입니다.");
-        }
-        if (request.getType() == null) {
-            throw new RuntimeException("타입은 필수입니다.");
-        }
-        if (request.getType() == Piece.Type.TEXT && (request.getContent() == null || request.getContent().trim().isEmpty())) {
-            throw new RuntimeException("텍스트 타입의 경우 내용(content)은 필수입니다.");
-        }
+    	if (request.getUserId() == null || request.getUserId().trim().isEmpty()) {
+    	    throw new RuntimeException("사용자 ID는 필수입니다.");
+    	}
+    	if (request.getType() == null || request.getType().trim().isEmpty()) {
+    	    throw new RuntimeException("타입은 필수입니다.");
+    	}
+    	if ("TEXT".equals(request.getType()) && (request.getContent() == null || request.getContent().trim().isEmpty())) {
+    	    throw new RuntimeException("텍스트 타입의 경우 내용(content)은 필수입니다.");
+    	}
 
-        // 사용자 존재 여부 및 상태 체크 (추가된 부분)
-        User user = userRepository.findByUserId(request.getUserId())
-            .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다."));
+    	// 사용자 존재 여부 및 상태 체크 (추가된 부분)
+    	User user = userRepository.findByUserId(request.getUserId())
+    	    .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다."));
 
-        if (user.getStatus() == User.Status.BANNED) {
-            throw new RuntimeException("차단된 사용자는 조각을 추가할 수 없습니다.");
-        }
-        if (user.getStatus() == User.Status.DELETED) {
-            throw new RuntimeException("존재하지 않는 사용자입니다.");
-        }
+    	if ("BANNED".equals(user.getStatus())) {
+    	    throw new RuntimeException("차단된 사용자는 조각을 추가할 수 없습니다.");
+    	}
+    	if ("DELETED".equals(user.getStatus())) {
+    	    throw new RuntimeException("존재하지 않는 사용자입니다.");
+    	}
 
-        if (request.getType() != Piece.Type.TEXT && file == null) {
-            throw new RuntimeException("TEXT 이외의 타입은 파일이 반드시 포함되어야 합니다.");
-        }
+    	if (!"TEXT".equals(request.getType()) && file == null) {
+    	    throw new RuntimeException("TEXT 이외의 타입은 파일이 반드시 포함되어야 합니다.");
+    	}
 
         String mediaId = null;
         String publicId = null;
@@ -205,14 +205,14 @@ public class PieceService {
 
         Map<String, PieceUpdateResponse.UpdateField> updatedFields = new LinkedHashMap<>();
 
-        if (request.getType() != null && request.getType() != piece.getType()) {
-            updatedFields.put("type", new PieceUpdateResponse.UpdateField(piece.getType().name(), request.getType().name()));
+        if (request.getType() != null && !request.getType().equals(piece.getType())) {
+            updatedFields.put("type", new PieceUpdateResponse.UpdateField(piece.getType(), request.getType()));
 
             handleTypeChange(piece, request, file, updatedFields);
             piece.setType(request.getType());
         }
 
-        if (file != null && piece.getType() != Piece.Type.TEXT) {
+        if (file != null && !"TEXT".equals(piece.getType())) {
             replaceExistingFile(piece, file, updatedFields);
         }
 
@@ -235,7 +235,7 @@ public class PieceService {
                                   Map<String, PieceUpdateResponse.UpdateField> updatedFields) {
         deleteExistingMediaIfExists(piece);
 
-        if (request.getType() == Piece.Type.TEXT) {
+        if ("TEXT".equals(request.getType())) {
             if (request.getContent() == null || request.getContent().trim().isEmpty()) {
                 throw new RuntimeException("TEXT 타입으로 변경 시 내용은 필수입니다.");
             }
@@ -266,11 +266,13 @@ public class PieceService {
     }
 
     private void updateAdditionalFields(Piece piece, PieceUpdateRequest request,
-                                        Map<String, PieceUpdateResponse.UpdateField> updatedFields) {
-        if (request.getContent() != null && piece.getType() == Piece.Type.TEXT && !request.getContent().equals(piece.getContent())) {
-            updatedFields.put("content", new PieceUpdateResponse.UpdateField(piece.getContent(), request.getContent()));
-            piece.setContent(request.getContent());
-        }
+            Map<String, PieceUpdateResponse.UpdateField> updatedFields) {
+    	
+		if (request.getContent() != null && "TEXT".equals(piece.getType())
+			&& !request.getContent().equals(piece.getContent())) {
+			updatedFields.put("content", new PieceUpdateResponse.UpdateField(piece.getContent(), request.getContent()));
+			piece.setContent(request.getContent());
+		}
 
         if (request.getTags() != null && !request.getTags().equals(piece.getTags())) {
             updatedFields.put("tags", new PieceUpdateResponse.UpdateField(piece.getTags(), request.getTags()));
@@ -290,7 +292,8 @@ public class PieceService {
 
     private void deleteExistingMediaIfExists(Piece piece) {
         if (piece.getMediaId() != null && piece.getPublicId() != null) {
-            String resourceType = (piece.getType() == Piece.Type.VIDEO || piece.getType() == Piece.Type.AUDIO) ? "video" : "image";
+            String type = piece.getType();
+            String resourceType = ("VIDEO".equals(type) || "AUDIO".equals(type)) ? "video" : "image";
             boolean deleted = cloudinaryService.deleteFromCloud(piece.getPublicId(), resourceType);
             if (!deleted) logger.warn("기존 파일이 이미 삭제되었거나 존재하지 않음. publicId: {}", piece.getPublicId());
         }

--- a/src/main/java/com/puzzlelog/api/service/UserService.java
+++ b/src/main/java/com/puzzlelog/api/service/UserService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +27,7 @@ import com.puzzlelog.api.dto.response.user.UserResponse;
 import com.puzzlelog.api.dto.response.user.UserUpdateResponse;
 import com.puzzlelog.api.repository.mongo.UserHistoryRepository;
 import com.puzzlelog.api.repository.mysql.UserRepository;
+import com.puzzlelog.api.repository.mysql.UserSpecifications;
 
 @Service
 public class UserService {
@@ -57,9 +60,10 @@ public class UserService {
     @Transactional(readOnly = true)
     public Page<UserResponse> findUsers(UserSearchRequest request, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        
-        return userRepository.searchUsers(request, pageable)
-                .map(UserResponse::from);
+
+        Specification<User> specs = UserSpecifications.withConditions(request);
+
+        return userRepository.findAll(specs, pageable).map(UserResponse::from);
     }
     
     // 사용자 정보 수정
@@ -71,63 +75,130 @@ public class UserService {
         Map<String, UserUpdateResponse.UpdateField> updatedFields = new HashMap<>();
         Map<String, Object> historyFields = new HashMap<>();
 
+        if ((request == null || request.isEmpty()) && (file == null || file.isEmpty())) {
+            throw new RuntimeException("수정된 내용이 없습니다.");
+        }
+
         if (request != null) {
-            if (request.getUserPwd() != null) {
+            if (request.hasUserPwd()) {
                 user.setUserPwd(passwordEncoder.encode(request.getUserPwd()));
                 updatedFields.put("userPwd", new UserUpdateResponse.UpdateField("(비밀번호 변경됨)", "(비밀번호 변경됨)"));
                 historyFields.put("userPwd", "(비밀번호 변경됨)");
             }
 
-            if (request.getNickname() != null && !request.getNickname().equals(user.getNickname())) {
-            	historyFields.put("nickname", Map.of("before", user.getNickname(), "after", request.getNickname()));
+            if (request.hasNickname() && !Objects.equals(request.getNickname(), user.getNickname())) {
+                Map<String, Object> nicknameHistory = new HashMap<>();
+                nicknameHistory.put("before", user.getNickname());
+                nicknameHistory.put("after", request.getNickname());
+
+                historyFields.put("nickname", nicknameHistory);
                 updatedFields.put("nickname", new UserUpdateResponse.UpdateField(user.getNickname(), request.getNickname()));
                 user.setNickname(request.getNickname());
             }
 
-            if (request.getBirthDate() != null && !request.getBirthDate().equals(user.getBirthDate().toString())) {
-            	historyFields.put("birthDate", Map.of("before", user.getBirthDate().toString(), "after", request.getBirthDate()));
-                updatedFields.put("birthDate", new UserUpdateResponse.UpdateField(user.getBirthDate().toString(), request.getBirthDate()));
-                user.setBirthDate(LocalDate.parse(request.getBirthDate()));
+            if (request.hasBirthDate()) {
+                String prevBirthDate = user.getBirthDate() != null ? user.getBirthDate().toString() : null;
+
+                if (!Objects.equals(request.getBirthDate(), prevBirthDate)) {
+                    Map<String, Object> birthDateHistory = new HashMap<>();
+                    birthDateHistory.put("before", prevBirthDate);
+                    birthDateHistory.put("after", request.getBirthDate());
+
+                    historyFields.put("birthDate", birthDateHistory);
+                    updatedFields.put("birthDate", new UserUpdateResponse.UpdateField(prevBirthDate, request.getBirthDate()));
+
+                    user.setBirthDate(request.getBirthDate() != null ? LocalDate.parse(request.getBirthDate()) : null);
+                }
+            }
+            
+            if (request.hasGender()) {
+                String prevGender = user.getGender();
+
+                if (!Objects.equals(request.getGender(), prevGender)) {
+                    Map<String, Object> genderHistory = new HashMap<>();
+                    genderHistory.put("before", prevGender);
+                    genderHistory.put("after", request.getGender());
+
+                    historyFields.put("gender", genderHistory);
+                    updatedFields.put("gender", new UserUpdateResponse.UpdateField(prevGender, request.getGender()));
+
+                    user.setGender(request.getGender());
+                }
             }
 
-            if (request.getGender() != null && !request.getGender().equals(user.getGender().name())) {
-            	historyFields.put("gender", Map.of("before", user.getGender().name(), "after", request.getGender()));
-                updatedFields.put("gender", new UserUpdateResponse.UpdateField(user.getGender().name(), request.getGender()));
-                user.setGender(User.Gender.valueOf(request.getGender()));
-            }
+            if (request.hasIsAlarm() && !request.getIsAlarm().equals(user.getIsAlarm())) {
+                Map<String, Object> isAlarmHistory = new HashMap<>();
+                isAlarmHistory.put("before", user.getIsAlarm());
+                isAlarmHistory.put("after", request.getIsAlarm());
 
-            if (request.getIsAlarm() != null && !request.getIsAlarm().equals(user.getIsAlarm())) {
-            	historyFields.put("isAlarm", Map.of("before", user.getIsAlarm(), "after", request.getIsAlarm()));
+                historyFields.put("isAlarm", isAlarmHistory);
                 updatedFields.put("isAlarm", new UserUpdateResponse.UpdateField(user.getIsAlarm(), request.getIsAlarm()));
                 user.setIsAlarm(request.getIsAlarm());
             }
 
-            // 프로필 이미지 삭제 처리 (null로 설정 시)
-            if (request.getProfileImg() == null && user.getProfileImg() != null && (file == null || file.isEmpty())) {
+            if (request.hasProfileImg() && request.getProfileImg() == null && user.getProfileImg() != null && (file == null || file.isEmpty())) {
                 String publicId = "$profile_" + userId;
+                String prevProfileImg = user.getProfileImg();
+
                 try {
                     boolean deleted = cloudinaryService.deleteFromCloud(publicId, "image");
                     if (!deleted) {
                         logger.warn("프로필 이미지가 이미 삭제되었거나 존재하지 않습니다: {}", publicId);
                     }
-                    historyFields.put("profileImg", Map.of("before", user.getProfileImg(), "after", null));
-                    updatedFields.put("profileImg", new UserUpdateResponse.UpdateField(user.getProfileImg(), null));
+
+                    Map<String, Object> profileImgHistory = new HashMap<>();
+                    profileImgHistory.put("before", prevProfileImg);
+                    profileImgHistory.put("after", null);
+
+                    historyFields.put("profileImg", profileImgHistory);
+                    updatedFields.put("profileImg", new UserUpdateResponse.UpdateField(prevProfileImg, null));
+
                     user.setProfileImg(null);
                 } catch (Exception e) {
                     throw new RuntimeException("프로필 이미지 삭제 실패: " + e.getMessage(), e);
                 }
             }
+            
+            /**
+             * @Admin : 관리자 기능
+             */
+            
+            if (request.hasStatus() && !Objects.equals(request.getStatus(), user.getStatus())) {
+                Map<String, Object> statusHistory = new HashMap<>();
+                statusHistory.put("before", user.getStatus());
+                statusHistory.put("after", request.getStatus());
+
+                historyFields.put("status", statusHistory);
+                updatedFields.put("status", new UserUpdateResponse.UpdateField(user.getStatus(), request.getStatus()));
+                user.setStatus(request.getStatus());
+            }
+
+            if (request.hasRole() && !Objects.equals(request.getRole(), user.getRole())) {
+                Map<String, Object> roleHistory = new HashMap<>();
+                roleHistory.put("before", user.getRole());
+                roleHistory.put("after", request.getRole());
+
+                historyFields.put("role", roleHistory);
+                updatedFields.put("role", new UserUpdateResponse.UpdateField(user.getRole(), request.getRole()));
+                user.setRole(request.getRole());
+            }
         }
 
-        // 프로필 이미지 업로드 처리 (덮어쓰기이므로 이전/이후 구분 없이 바로 mediaId 반환)
         String mediaId = null;
         if (file != null && !file.isEmpty()) {
             String publicId = "$profile_" + userId;
+            String prevProfileImg = user.getProfileImg();
             try {
                 CloudinaryUploadResponse uploadResult = cloudinaryService.uploadImageToCloud(file, publicId);
-                mediaId = uploadResult.getUrl(); // 업로드된 URL
-                historyFields.put("profileImg", Map.of("before", user.getProfileImg(), "after", mediaId));
-                updatedFields.put("profileImg", new UserUpdateResponse.UpdateField(user.getProfileImg(), mediaId));
+                mediaId = uploadResult.getUrl();
+
+                Map<String, Object> profileImgHistory = new HashMap<>();
+                profileImgHistory.put("before", prevProfileImg);
+                profileImgHistory.put("after", mediaId);
+
+                historyFields.put("profileImg", profileImgHistory);
+                updatedFields.put("profileImg", new UserUpdateResponse.UpdateField(prevProfileImg, mediaId));
+
                 user.setProfileImg(mediaId);
             } catch (Exception e) {
                 throw new RuntimeException("프로필 이미지 업로드 실패: " + e.getMessage(), e);
@@ -139,12 +210,11 @@ public class UserService {
         }
 
         userRepository.save(user);
-        
-        // MongoDB 기록 추가
+
         userHistoryRepository.save(UserHistory.builder()
             .userId(userId)
             .action("UPDATE")
-            .reason("본인 수정") // 관리자는 다른 메서드에서 처리
+            .reason("본인 수정")
             .changedBy(userId)
             .timestamp(LocalDateTime.now())
             .changedFields(historyFields)
@@ -153,9 +223,9 @@ public class UserService {
         return UserUpdateResponse.builder()
             .userId(user.getUserId())
             .updatedFields(updatedFields)
-            .mediaId(mediaId)  // 새로 추가된 필드, 프로필 이미지 URL 직접 반환
+            .mediaId(mediaId)
             .build();
-    }  
+    }
 
     // 사용자 비활성화 (상태를 DELETED로 변경)
     @Transactional
@@ -163,7 +233,9 @@ public class UserService {
         User user = userRepository.findByUserId(userId)
             .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        user.setStatus(User.Status.DELETED);
+        String prevStatus = user.getStatus();
+
+        user.setStatus("DELETED");
         userRepository.save(user);
         
         // ✅ MongoDB 삭제 기록 추가
@@ -173,10 +245,10 @@ public class UserService {
             .reason("본인 삭제")
             .changedBy(userId)
             .timestamp(LocalDateTime.now())
-            .changedFields(Map.of("status", Map.of("before", "ACTIVE", "after", "DELETED")))
+            .changedFields(Map.of("status", Map.of("before", prevStatus, "after", "DELETED")))
             .build());
     }
-    
+ 
     // 중복 체크
     @Transactional(readOnly = true)
     public boolean checkDuplicate(String type, String value) {


### PR DESCRIPTION
1. 프로필(profile)과 닉네임(nickname) 수정이 안 되는 문제 해결 (null이 들어간 경우 수정이 안 되는 문제)
2. 성별(Gender)와 생년월일(birthDate) 수정이 안 되는 문제 해결 (null이 들어간 경우 수정이 안 되는 문제)
3. 프로필과 닉네임, 성별, 생년월일에 명시적으로 null을 넣을 경우와 칼럼을 생략할 경우를 분리,
  - 명시적으로 null을 넣을 경우에는 (NULL)의 형태로 빈 형태로 들어간다.
  - 칼럼을 생략할 경우에는 생략한 칼럼은 수정되지 않는다.
4. 각 Entity와 Document의 Enum 형태의 데이터를 String 형태의 데이터로 수정 (그로 인해 파생되는 DTO와 Service도 수정)
5. UserRepository의 복잡한 @Query(Mybatis 형태)를 JPA 형태로 수정, 쿼리 형태는 UserSpecifications로 분리