### PR TITLE
feat: implement CRUD APIs for Diary & DiaryElement with logical delet…

### DIFF
--- a/src/main/java/com/puzzlelog/api/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/puzzlelog/api/config/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/com/puzzlelog/api/controller/AlbumController.java
+++ b/src/main/java/com/puzzlelog/api/controller/AlbumController.java
@@ -1,8 +1,8 @@
 package com.puzzlelog.api.controller;
 
-import com.puzzlelog.api.config.ApiResponse;
 import com.puzzlelog.api.dto.request.album.AlbumRequest;
 import com.puzzlelog.api.dto.response.album.AlbumResponse;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 import com.puzzlelog.api.service.AlbumService;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/puzzlelog/api/controller/DiaryController.java
+++ b/src/main/java/com/puzzlelog/api/controller/DiaryController.java
@@ -4,8 +4,10 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,12 +15,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.puzzlelog.api.config.ApiResponse;
-import com.puzzlelog.api.dto.request.diary.DiaryRequest;
-import com.puzzlelog.api.dto.request.diary.DiarySearchRequest;
-import com.puzzlelog.api.dto.response.diary.DiaryDetailResponse;
-import com.puzzlelog.api.dto.response.diary.DiaryResponse;
-import com.puzzlelog.api.dto.response.diary.PagedDiaryResponse;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementsOrderUpdateRequest;
+import com.puzzlelog.api.dto.request.diary.meta.DiaryMetaUpdateRequest;
+import com.puzzlelog.api.dto.request.diary.meta.DiaryRequest;
+import com.puzzlelog.api.dto.request.diary.meta.DiarySearchRequest;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementsOrderResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryDeleteResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryDetailResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryMetaUpdateResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryResponse;
+import com.puzzlelog.api.dto.response.diary.meta.PagedDiaryResponse;
 import com.puzzlelog.api.service.DiaryService;
 
 import lombok.RequiredArgsConstructor;
@@ -58,20 +65,30 @@ public class DiaryController {
 	    return ResponseEntity.ok(ApiResponse.success(response, "일기 목록 조회 성공"));
 	}
 	
-//    // 특정 일기 수정
-//    @PatchMapping("/{diaryId}")
-//    public ResponseEntity<ApiResponse<DiaryResponse>> updateDiary(
-//            @PathVariable String diaryId,
-//            @RequestBody DiaryUpdateRequest request) {
-//
-//        // Service 구현 예정
-//        return ResponseEntity.ok(ApiResponse.success(null, "일기 수정 성공"));
-//    }
-//
-//    // 특정 일기 삭제 (논리 삭제)
-//    @DeleteMapping("/{diaryId}")
-//    public ResponseEntity<ApiResponse<Void>> deleteDiary(@PathVariable String diaryId) {
-//        // Service 구현 예정
-//        return ResponseEntity.ok(ApiResponse.successMessage("일기 삭제 성공"));
-//    }
+	// 특정 일기 메타 정보 수정
+	@PatchMapping("/{diaryId}/meta")
+	public ResponseEntity<ApiResponse<DiaryMetaUpdateResponse>> updateDiaryMeta(
+	        @PathVariable String diaryId,
+	        @RequestBody DiaryMetaUpdateRequest request) {
+
+	    DiaryMetaUpdateResponse response = diaryService.updateDiaryMeta(diaryId, request);
+	    return ResponseEntity.ok(ApiResponse.success(response, "일기 메타 정보 수정 성공"));
+	}
+	
+	// 일기 요소 순서 변경
+	@PatchMapping("/{diaryId}/elements-orders")
+	public ResponseEntity<ApiResponse<DiaryElementsOrderResponse>> updateDiaryElements(
+	        @PathVariable String diaryId,
+	        @RequestBody DiaryElementsOrderUpdateRequest request) {
+
+	    DiaryElementsOrderResponse response = diaryService.updateDiaryElements(diaryId, request);
+	    return ResponseEntity.ok(ApiResponse.success(response, "일기 요소 순서 수정 성공"));
+	}
+	
+	// 특정 일기 삭제 (논리 삭제)
+	@DeleteMapping("/{diaryId}")
+	public ResponseEntity<ApiResponse<DiaryDeleteResponse>> deleteDiary(@PathVariable String diaryId) {
+	    DiaryDeleteResponse response = diaryService.deleteDiary(diaryId);
+	    return ResponseEntity.ok(ApiResponse.success(response, "일기 삭제 성공"));
+	}
 }

--- a/src/main/java/com/puzzlelog/api/controller/DiaryElementController.java
+++ b/src/main/java/com/puzzlelog/api/controller/DiaryElementController.java
@@ -1,0 +1,95 @@
+package com.puzzlelog.api.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementRequest;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementSearchRequest;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementUpdateRequest;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementDeleteResponse;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementResponse;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementUpdateResponse;
+import com.puzzlelog.api.dto.response.diary.element.PagedDiaryElementResponse;
+import com.puzzlelog.api.service.DiaryElementService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/diaries/{diaryId}/elements")
+@RequiredArgsConstructor
+public class DiaryElementController {
+
+	private final DiaryElementService diaryElementService;
+	
+	/**
+	 *  POST /elements (요소 생성 및 일기 추가)
+			요소 생성과 동시에 일기에 즉시 연결됩니다.
+			따라서 요청 데이터에 반드시 diaryId를 포함해야 합니다.
+	 */
+	
+	// 요소 생성
+	@PostMapping
+	public ResponseEntity<ApiResponse<DiaryElementResponse>> createElement(
+	        @PathVariable String diaryId,
+	        @Valid @RequestBody DiaryElementRequest request) {
+
+	    DiaryElementResponse response = diaryElementService.createDiaryElement(diaryId, request);
+
+	    return ResponseEntity.ok(ApiResponse.success(response, "요소 생성 성공"));
+	}
+
+	// 특정 요소 개별 조회
+	@GetMapping("/{elementId}")
+	public ResponseEntity<ApiResponse<DiaryElementResponse>> getElement(
+	        @PathVariable String diaryId,
+	        @PathVariable String elementId) {
+
+	    DiaryElementResponse response = diaryElementService.getElement(diaryId, elementId);
+	    return ResponseEntity.ok(ApiResponse.success(response, "요소 조회 성공"));
+	}
+	
+	// 요소 목록 조회 (필터링 + 페이징 지원)
+	@GetMapping
+	public ResponseEntity<ApiResponse<PagedDiaryElementResponse>> getElements(
+	        @PathVariable String diaryId,
+	        @ModelAttribute DiaryElementSearchRequest request) {
+
+	    PagedDiaryElementResponse response = diaryElementService.getElements(diaryId, request);
+	    return ResponseEntity.ok(ApiResponse.success(response, "요소 목록 조회 성공"));
+	}
+
+	// 특정 요소 수정
+	@PatchMapping("/{elementId}")
+	public ResponseEntity<ApiResponse<DiaryElementUpdateResponse>> updateElement(
+	        @PathVariable("diaryId") String diaryId,
+	        @PathVariable("elementId") String elementId,
+	        @RequestBody DiaryElementUpdateRequest request) {
+
+	    DiaryElementUpdateResponse response = diaryElementService.updateDiaryElement(diaryId, elementId, request);
+
+	    return ResponseEntity.ok(ApiResponse.success(response, "요소 수정 성공"));
+	}
+
+	// 특정 요소 삭제 (논리 삭제)
+	@DeleteMapping("/{elementId}")
+	public ResponseEntity<ApiResponse<DiaryElementDeleteResponse>> deleteElement(
+	        @PathVariable String diaryId,
+	        @PathVariable String elementId) {
+
+	    DiaryElementDeleteResponse response = diaryElementService.deleteDiaryElement(diaryId, elementId);
+
+	    return ResponseEntity.ok(ApiResponse.success(response, "요소 삭제 성공"));
+	}
+	
+}

--- a/src/main/java/com/puzzlelog/api/controller/FriendController.java
+++ b/src/main/java/com/puzzlelog/api/controller/FriendController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.puzzlelog.api.config.ApiResponse;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 import com.puzzlelog.api.dto.response.friend.FriendResponse;
 import com.puzzlelog.api.dto.response.friend.PagedFriendResponse;
 import com.puzzlelog.api.service.FriendService;

--- a/src/main/java/com/puzzlelog/api/controller/PieceController.java
+++ b/src/main/java/com/puzzlelog/api/controller/PieceController.java
@@ -17,10 +17,10 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.puzzlelog.api.config.ApiResponse;
 import com.puzzlelog.api.dto.request.piece.PieceRequest;
 import com.puzzlelog.api.dto.request.piece.PieceSearchRequest;
 import com.puzzlelog.api.dto.request.piece.PieceUpdateRequest;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 import com.puzzlelog.api.dto.response.piece.PagedPieceResponse;
 import com.puzzlelog.api.dto.response.piece.PieceDeleteResponse;
 import com.puzzlelog.api.dto.response.piece.PieceResponse;

--- a/src/main/java/com/puzzlelog/api/controller/PostController.java
+++ b/src/main/java/com/puzzlelog/api/controller/PostController.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.*;
 import com.puzzlelog.api.dao.document.Comment;
 import com.puzzlelog.api.dao.document.Post;
 import com.puzzlelog.api.dto.request.comment.CommentRequest;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 import com.puzzlelog.api.service.CommentService;
 import com.puzzlelog.api.service.PostService;
-import com.puzzlelog.api.config.ApiResponse;
 
 import java.util.List;
 

--- a/src/main/java/com/puzzlelog/api/controller/StickerController.java
+++ b/src/main/java/com/puzzlelog/api/controller/StickerController.java
@@ -1,7 +1,7 @@
 package com.puzzlelog.api.controller;
 
-import com.puzzlelog.api.config.ApiResponse;
 import com.puzzlelog.api.dao.document.Sticker;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 import com.puzzlelog.api.service.AuthService;
 import com.puzzlelog.api.service.StickerService;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/puzzlelog/api/controller/UserController.java
+++ b/src/main/java/com/puzzlelog/api/controller/UserController.java
@@ -16,13 +16,13 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.puzzlelog.api.config.ApiResponse;
 import com.puzzlelog.api.dto.request.auth.LoginRequest;
 import com.puzzlelog.api.dto.request.auth.SignupRequest;
 import com.puzzlelog.api.dto.request.user.UserSearchRequest;
 import com.puzzlelog.api.dto.request.user.UserUpdateRequest;
 import com.puzzlelog.api.dto.response.auth.LoginResponse;
 import com.puzzlelog.api.dto.response.auth.SignupResponse;
+import com.puzzlelog.api.dto.response.common.ApiResponse;
 import com.puzzlelog.api.dto.response.user.PagedUserResponse;
 import com.puzzlelog.api.dto.response.user.UserResponse;
 import com.puzzlelog.api.dto.response.user.UserUpdateResponse;

--- a/src/main/java/com/puzzlelog/api/dao/document/Diary.java
+++ b/src/main/java/com/puzzlelog/api/dao/document/Diary.java
@@ -27,8 +27,10 @@ public class Diary {
     private String userId;
     private String title;
     
-    // 일기 내부 요소
-    private List<String> elementIds; // DiaryElement 컬렉션의 ID 리스트 (요소 순서대로 저장)
+    /** 일기 내부에 존재하는 요소(Element)
+     * 우선 순위가 존재하여 뒤에 있을 수록 위에 존재한다.
+     */
+    private List<String> elementIds; // DiaryElement 컬렉션의 ID 리스트
     
     // 배경 설정
     private String backgroundContentId; // 이미지 Content Id, null 가능

--- a/src/main/java/com/puzzlelog/api/dao/document/DiaryElement.java
+++ b/src/main/java/com/puzzlelog/api/dao/document/DiaryElement.java
@@ -21,29 +21,27 @@ import lombok.Setter;
 @Document(collection = "diary_elements")
 public class DiaryElement {
 
-    @Id
-    private String elementId;      // 자동으로 생성된 ObjectId 값을 문자열로 저장 [클라이언트의 UUID와는 다른 서버의 ObjectId]
+	@Id
+	private String id;
 
-    // 조각 개인정보
-    private String diaryId;      // 소속된 Diary ID
-    private String elementType;    // PIECE(TEXT, IMAGE, VIDEO, AUDIO), STICKER, DRAWING
-    private String contentId;    // Piece, Sticker의 원본 콘텐츠 ID (DRAWING은 null 가능)
-    
-    private String drawingData;      // DRAWING 타입일 때만 SVG 데이터 저장, 그 외는 null
-    
-    // 필수 기본 변형 스타일 (위치 및 변형 정보)
-    @Builder.Default
-    private List<Double> position = List.of(0.0, 0.0);  // 기본값 [0.0, 0.0] - [x, y]
-    @Builder.Default
-    private Double scale = 1.0;                         // 기본값 1.0 - size
-    @Builder.Default
-    private Double rotation = 0.0;                      // 기본값 0.0 (회전 없음) - angle
+    private String diaryId;
+    private String elementType; // TEXT, IMAGE, AUDIO, VIDEO, STICKER, DRAWING
+    private String contentId;
+    private String drawingData;
 
-    private ElementDecoration decoration; // 확장 편집 요소
-    
-    private Integer elementOrder;   // 우선순위 (값이 높을수록 위에 표시)
+    @Builder.Default
+    private List<Double> position = List.of(0.0, 0.0);
+    @Builder.Default
+    private Double scale = 1.0;
+    @Builder.Default
+    private Double rotation = 0.0;
+
+    private ElementDecoration decoration;
 
     @CreatedDate
     private Instant createdAt;
     private Instant updatedAt;
+
+    @Builder.Default
+    private Boolean isDeleted = false; // 논리적 삭제 여부
 }

--- a/src/main/java/com/puzzlelog/api/dao/document/ElementDecoration.java
+++ b/src/main/java/com/puzzlelog/api/dao/document/ElementDecoration.java
@@ -1,7 +1,14 @@
 package com.puzzlelog.api.dao.document;
 
-import lombok.*;
 import java.util.List;
+
+import com.puzzlelog.api.dto.request.diary.element.ElementDecorationRequest;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -33,4 +40,25 @@ public class ElementDecoration {
 
     // 부가 효과 (외부 라이브러리 또는 AI 기반 특수 효과)
     private List<String> effects;    // ["blur", "background_removal", "recolor"...]
+    
+    public static ElementDecoration from(ElementDecorationRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        return ElementDecoration.builder()
+            .borderColor(request.getBorderColor())
+            .opacity(request.getOpacity())
+            .font(request.getFont())
+            .fontSize(request.getFontSize())
+            .color(request.getColor())
+            .fontStyle(request.getFontStyle())
+            .align(request.getAlign())
+            .crop(request.getCrop())
+            .startOffset(request.getStartOffset())
+            .endOffset(request.getEndOffset())
+            .volume(request.getVolume())
+            .effects(request.getEffects())
+            .build();
+    }
 }

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementRequest.java
@@ -1,9 +1,8 @@
-package com.puzzlelog.api.dto.request.diary;
+package com.puzzlelog.api.dto.request.diary.element;
 
 import java.util.List;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 import lombok.*;
 
@@ -20,9 +19,6 @@ public class DiaryElementRequest {
     private String contentId;     // DRAWING일 때 null 허용
     private String drawingData;   // DRAWING 타입일 때만 필수
 
-    @NotNull(message = "요소의 순서는 명시적으로 지정되어야 합니다.")
-    private Integer elementOrder;
-
     @Builder.Default
     private List<Double> position = List.of(0.0, 0.0);
 
@@ -33,4 +29,13 @@ public class DiaryElementRequest {
     private Double rotation = 0.0;
 
     private ElementDecorationRequest decoration;  
+    
+    // DTO 레벨의 간단한 타입별 검증 메서드
+    public boolean isValidByType() {
+        if ("DRAWING".equals(elementType)) {
+            return drawingData != null && !drawingData.isBlank() && (contentId == null || contentId.isBlank());
+        } else {
+            return contentId != null && !contentId.isBlank() && (drawingData == null || drawingData.isBlank());
+        }
+    }
 }

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementSearchRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementSearchRequest.java
@@ -1,0 +1,14 @@
+package com.puzzlelog.api.dto.request.diary.element;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DiaryElementSearchRequest {
+    private String elementType;  // 필터링할 요소 타입 (TEXT, IMAGE, AUDIO, VIDEO, STICKER, DRAWING)
+    private int page;            // 페이징 페이지 번호
+    private int size;            // 페이지 크기
+}

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementUpdateRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.puzzlelog.api.dto.request.diary.element;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DiaryElementUpdateRequest {
+
+    private String contentId;     // 동일 타입 내 변경 가능
+    private String drawingData;   // DRAWING 타입만 가능
+
+    private List<Double> position;
+    private Double scale;
+    private Double rotation;
+    private ElementDecorationRequest decoration;
+}

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementsOrderUpdateRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/element/DiaryElementsOrderUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.puzzlelog.api.dto.request.diary.element;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryElementsOrderUpdateRequest {
+	// 조각의 순서 변경을 처리 (추가와 삭제는 API로만 처리)
+    private List<String> elementIds; // 요소의 순서를 포함한 전체 요소 ID 목록
+}

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/element/ElementDecorationRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/element/ElementDecorationRequest.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.dto.request.diary;
+package com.puzzlelog.api.dto.request.diary.element;
 
 import lombok.*;
 import java.util.List;

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/meta/DiaryMetaUpdateRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/meta/DiaryMetaUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.puzzlelog.api.dto.request.diary.meta;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryMetaUpdateRequest {
+    private String title;
+    private String backgroundContentId;
+    private String themeColor;
+    private String emotionContentId;
+    private Boolean isShared;
+    private Instant openAt;
+}

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/meta/DiaryRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/meta/DiaryRequest.java
@@ -1,10 +1,12 @@
-package com.puzzlelog.api.dto.request.diary;
+package com.puzzlelog.api.dto.request.diary.meta;
 
 import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
+
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementRequest;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/puzzlelog/api/dto/request/diary/meta/DiarySearchRequest.java
+++ b/src/main/java/com/puzzlelog/api/dto/request/diary/meta/DiarySearchRequest.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.dto.request.diary;
+package com.puzzlelog.api.dto.request.diary.meta;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/puzzlelog/api/dto/response/common/ApiResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/common/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.config;
+package com.puzzlelog.api.dto.response.common;
 
 import lombok.*;
 

--- a/src/main/java/com/puzzlelog/api/dto/response/common/Pagination.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/common/Pagination.java
@@ -1,0 +1,40 @@
+package com.puzzlelog.api.dto.response.common;
+
+import org.springframework.data.domain.Page;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Pagination {
+    private int currentPage;
+    private int pageSize;
+    private int totalPages;
+    private long totalElements;
+    private boolean first;
+    private boolean last;
+
+    public static Pagination from(Page<?> page) {
+        return Pagination.builder()
+                .currentPage(page.getNumber())
+                .pageSize(page.getSize())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .build();
+    }
+
+    public static Pagination of(int currentPage, int pageSize, long totalElements) {
+        return Pagination.builder()
+                .currentPage(currentPage)
+                .pageSize(pageSize)
+                .totalElements(totalElements)
+                .totalPages((int) Math.ceil((double) totalElements / pageSize))
+                .first(currentPage == 0)
+                .last((long) (currentPage + 1) * pageSize >= totalElements)
+                .build();
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementDeleteResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementDeleteResponse.java
@@ -1,0 +1,24 @@
+package com.puzzlelog.api.dto.response.diary.element;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryElementDeleteResponse {
+    private String diaryId;   // 일기 ID
+    private String elementId; // 삭제 처리된 요소 ID
+
+    public static DiaryElementDeleteResponse of(String diaryId, String elementId) {
+        return DiaryElementDeleteResponse.builder()
+            .diaryId(diaryId)
+            .elementId(elementId)
+            .build();
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementResponse.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.dto.response.diary;
+package com.puzzlelog.api.dto.response.diary.element;
 
 import java.time.Instant;
 import java.util.List;
@@ -17,14 +17,13 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class DiaryElementResponse {
-    private String elementId;
+    private String id;
     private String elementType;
     private String contentId; 
     private String drawingData;
     private List<Double> position;
     private Double scale;
     private Double rotation;
-    private Integer elementOrder;
     private Instant createdAt;
     private Instant updatedAt;
 
@@ -32,14 +31,13 @@ public class DiaryElementResponse {
     
     public static DiaryElementResponse from(DiaryElement element) {
         return DiaryElementResponse.builder()
-            .elementId(element.getElementId())
+            .id(element.getId())
             .elementType(element.getElementType())
             .contentId(element.getContentId())
             .drawingData(element.getDrawingData())
             .position(element.getPosition())
             .scale(element.getScale())
             .rotation(element.getRotation())
-            .elementOrder(element.getElementOrder())
             .createdAt(element.getCreatedAt())
             .updatedAt(element.getUpdatedAt())
             .decoration(null) // 현재는 null (추후 구현 예정)

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementUpdateResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementUpdateResponse.java
@@ -1,0 +1,28 @@
+package com.puzzlelog.api.dto.response.diary.element;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DiaryElementUpdateResponse {
+    private String elementId;
+    private Map<String, UpdateField> updatedFields;
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateField {
+        private Object before;
+        private Object after;
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementsOrderResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/element/DiaryElementsOrderResponse.java
@@ -1,0 +1,25 @@
+package com.puzzlelog.api.dto.response.diary.element;
+
+import lombok.*;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryElementsOrderResponse {
+    private String diaryId;
+    private List<String> elementIds;
+    private Instant updatedAt;
+
+    public static DiaryElementsOrderResponse of(String diaryId, List<String> elementIds, Instant updatedAt) {
+        return DiaryElementsOrderResponse.builder()
+                .diaryId(diaryId)
+                .elementIds(elementIds)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/element/ElementDecorationResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/element/ElementDecorationResponse.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.dto.response.diary;
+package com.puzzlelog.api.dto.response.diary.element;
 
 import lombok.Builder;
 

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/element/PagedDiaryElementResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/element/PagedDiaryElementResponse.java
@@ -1,0 +1,32 @@
+package com.puzzlelog.api.dto.response.diary.element;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.puzzlelog.api.dao.document.DiaryElement;
+import com.puzzlelog.api.dto.response.common.Pagination;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagedDiaryElementResponse {
+    private List<DiaryElementResponse> elements;
+    private Pagination pagination;
+
+    public static PagedDiaryElementResponse of(List<DiaryElement> elements, int page, int size, long totalElements) {
+        return PagedDiaryElementResponse.builder()
+            .elements(elements.stream()
+                .map(DiaryElementResponse::from)
+                .collect(Collectors.toList()))
+            .pagination(Pagination.of(page, size, totalElements))
+            .build();
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryDeleteResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryDeleteResponse.java
@@ -1,0 +1,24 @@
+package com.puzzlelog.api.dto.response.diary.meta;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryDeleteResponse {
+    private String diaryId; // 삭제 처리된 일기 ID
+    private String userId;  // 사용자 ID
+
+    public static DiaryDeleteResponse of(String diaryId, String userId) {
+        return DiaryDeleteResponse.builder()
+            .diaryId(diaryId)
+            .userId(userId)
+            .build();
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryDetailResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryDetailResponse.java
@@ -1,8 +1,12 @@
-package com.puzzlelog.api.dto.response.diary;
+package com.puzzlelog.api.dto.response.diary.meta;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.puzzlelog.api.dao.document.Diary;
+import com.puzzlelog.api.dao.document.DiaryElement;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementResponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +19,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class DiarySimpleResponse {
+public class DiaryDetailResponse {
     private String diaryId;
     private String userId;
     private String title;
@@ -23,12 +27,14 @@ public class DiarySimpleResponse {
     private String themeColor;
     private String emotionContentId;
     private Boolean isShared;
-    private Instant openAt;
+    private Instant openAt;  // 타임캡슐 여부 (없으면 null)
     private Instant createdAt;
     private Instant updatedAt;
 
-    public static DiarySimpleResponse from(Diary diary) {
-        return DiarySimpleResponse.builder()
+    private List<DiaryElementResponse> elements;  // 요소 상세 정보 리스트
+    
+    public static DiaryDetailResponse from(Diary diary, List<DiaryElement> elements) {
+        return DiaryDetailResponse.builder()
             .diaryId(diary.getId())
             .userId(diary.getUserId())
             .title(diary.getTitle())
@@ -36,9 +42,12 @@ public class DiarySimpleResponse {
             .themeColor(diary.getThemeColor())
             .emotionContentId(diary.getEmotionContentId())
             .isShared(diary.getIsShared())
-            .openAt(diary.getOpenAt())
             .createdAt(diary.getCreatedAt())
             .updatedAt(diary.getUpdatedAt())
+            .openAt(diary.getOpenAt())
+            .elements(elements.stream()
+                .map(DiaryElementResponse::from)
+                .collect(Collectors.toList()))
             .build();
     }
 }

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryMetaUpdateResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryMetaUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.puzzlelog.api.dto.response.diary.meta;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DiaryMetaUpdateResponse {
+    private String diaryId;
+    private Map<String, UpdateField> updatedFields;
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class UpdateField {
+        private Object before;
+        private Object after;
+    }
+}

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiaryResponse.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.dto.response.diary;
+package com.puzzlelog.api.dto.response.diary.meta;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiarySimpleResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/meta/DiarySimpleResponse.java
@@ -1,11 +1,8 @@
-package com.puzzlelog.api.dto.response.diary;
+package com.puzzlelog.api.dto.response.diary.meta;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import com.puzzlelog.api.dao.document.Diary;
-import com.puzzlelog.api.dao.document.DiaryElement;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +15,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class DiaryDetailResponse {
+public class DiarySimpleResponse {
     private String diaryId;
     private String userId;
     private String title;
@@ -26,14 +23,12 @@ public class DiaryDetailResponse {
     private String themeColor;
     private String emotionContentId;
     private Boolean isShared;
-    private Instant openAt;  // 타임캡슐 여부 (없으면 null)
+    private Instant openAt;
     private Instant createdAt;
     private Instant updatedAt;
 
-    private List<DiaryElementResponse> elements;  // 요소 상세 정보 리스트
-    
-    public static DiaryDetailResponse from(Diary diary, List<DiaryElement> elements) {
-        return DiaryDetailResponse.builder()
+    public static DiarySimpleResponse from(Diary diary) {
+        return DiarySimpleResponse.builder()
             .diaryId(diary.getId())
             .userId(diary.getUserId())
             .title(diary.getTitle())
@@ -41,12 +36,9 @@ public class DiaryDetailResponse {
             .themeColor(diary.getThemeColor())
             .emotionContentId(diary.getEmotionContentId())
             .isShared(diary.getIsShared())
+            .openAt(diary.getOpenAt())
             .createdAt(diary.getCreatedAt())
             .updatedAt(diary.getUpdatedAt())
-            .openAt(diary.getOpenAt())
-            .elements(elements.stream()
-                .map(DiaryElementResponse::from)
-                .collect(Collectors.toList()))
             .build();
     }
 }

--- a/src/main/java/com/puzzlelog/api/dto/response/diary/meta/PagedDiaryResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/diary/meta/PagedDiaryResponse.java
@@ -1,4 +1,4 @@
-package com.puzzlelog.api.dto.response.diary;
+package com.puzzlelog.api.dto.response.diary.meta;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 
 import com.puzzlelog.api.dao.document.Diary;
+import com.puzzlelog.api.dto.response.common.Pagination;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,40 +16,31 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PagedDiaryResponse {
-    private int totalPages;
-    private long totalElements;
-    private int currentPage;
-    private int size;
-    private List<DiarySimpleResponse> diaries;
 
+    private List<DiarySimpleResponse> diaries;
+    private Pagination pagination;
+
+    // JPA 사용시 메서드
     public static PagedDiaryResponse from(Page<Diary> page) {
         return PagedDiaryResponse.builder()
-                .totalPages(page.getTotalPages())
-                .totalElements(page.getTotalElements())
-                .currentPage(page.getNumber())
-                .size(page.getSize())
                 .diaries(page.getContent().stream()
                         .map(DiarySimpleResponse::from)
                         .collect(Collectors.toList()))
+                .pagination(Pagination.from(page))
                 .build();
     }
     
+    // 몽고DB 사용시 메서드
     public static PagedDiaryResponse of(List<Diary> diaries, int currentPage, int size, long totalElements) {
-        int totalPages = (int) Math.ceil((double) totalElements / size);
-
         return PagedDiaryResponse.builder()
-            .totalPages(totalPages)
-            .totalElements(totalElements)
-            .currentPage(currentPage)
-            .size(size)
-            .diaries(diaries.stream()
-                .map(DiarySimpleResponse::from)
-                .collect(Collectors.toList()))
-            .build();
+                .diaries(diaries.stream()
+                        .map(DiarySimpleResponse::from)
+                        .collect(Collectors.toList()))
+                .pagination(Pagination.of(currentPage, size, totalElements))
+                .build();
     }
-
 }

--- a/src/main/java/com/puzzlelog/api/dto/response/friend/PagedFriendResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/friend/PagedFriendResponse.java
@@ -3,6 +3,8 @@ package com.puzzlelog.api.dto.response.friend;
 import java.util.List;
 import org.springframework.data.domain.Page;
 
+import com.puzzlelog.api.dto.response.common.Pagination;
+
 import lombok.*;
 
 @Getter
@@ -19,30 +21,5 @@ public class PagedFriendResponse {
             .friends(page.getContent())
             .pagination(Pagination.from(page))
             .build();
-    }
-
-    @Getter
-    @Setter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class Pagination {
-        private int currentPage;
-        private int pageSize;
-        private int totalPages;
-        private long totalElements;
-        private boolean isFirst;
-        private boolean isLast;
-
-        public static Pagination from(Page<?> page) {
-            return Pagination.builder()
-                    .currentPage(page.getNumber())
-                    .pageSize(page.getSize())
-                    .totalPages(page.getTotalPages())
-                    .totalElements(page.getTotalElements())
-                    .isFirst(page.isFirst())
-                    .isLast(page.isLast())
-                    .build();
-        }
     }
 }

--- a/src/main/java/com/puzzlelog/api/dto/response/piece/PagedPieceResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/piece/PagedPieceResponse.java
@@ -3,7 +3,10 @@ package com.puzzlelog.api.dto.response.piece;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+
 import com.puzzlelog.api.dao.document.Piece;
+import com.puzzlelog.api.dto.response.common.Pagination;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,50 +25,18 @@ public class PagedPieceResponse {
     private Pagination pagination;
 
     // 기존 메서드 유지 (JPA 사용 시 편의 메서드)
-    public static PagedPieceResponse from(org.springframework.data.domain.Page<PieceResponse> page) {
+    public static PagedPieceResponse from(Page<PieceResponse> page) {
         return PagedPieceResponse.builder()
                 .pieces(page.getContent())
                 .pagination(Pagination.from(page))
                 .build();
     }
 
-    // MongoDB에서 사용할 새 메서드 추가
+    // MongoDB에서 사용할 메서드
     public static PagedPieceResponse of(List<Piece> pieceList, int page, int size, long totalElements) {
         return PagedPieceResponse.builder()
-            .pieces(pieceList.stream().map(PieceResponse::from).collect(Collectors.toList()))
-            .pagination(Pagination.builder()
-                .currentPage(page)
-                .pageSize(size)
-                .totalElements(totalElements)
-                .totalPages((int) Math.ceil((double) totalElements / size))
-                .first(page == 0)
-                .last((long) (page + 1) * size >= totalElements)
-                .build())
-            .build();
-    }
-
-    @Getter
-    @Setter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class Pagination {
-        private int currentPage;
-        private int pageSize;
-        private int totalPages;
-        private long totalElements;
-        private boolean first;
-        private boolean last;
-
-        public static Pagination from(org.springframework.data.domain.Page<?> page) {
-            return Pagination.builder()
-                    .currentPage(page.getNumber())
-                    .pageSize(page.getSize())
-                    .totalPages(page.getTotalPages())
-                    .totalElements(page.getTotalElements())
-                    .first(page.isFirst())
-                    .last(page.isLast())
-                    .build();
-        }
+                .pieces(pieceList.stream().map(PieceResponse::from).collect(Collectors.toList()))
+                .pagination(Pagination.of(page, size, totalElements))
+                .build();
     }
 }

--- a/src/main/java/com/puzzlelog/api/dto/response/user/PagedUserResponse.java
+++ b/src/main/java/com/puzzlelog/api/dto/response/user/PagedUserResponse.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 
+import com.puzzlelog.api.dto.response.common.Pagination;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,31 +20,6 @@ import lombok.Setter;
 public class PagedUserResponse {
     private List<UserResponse> users;
     private Pagination pagination;
-
-    @Getter
-    @Setter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class Pagination {
-        private int currentPage;
-        private int pageSize;
-        private int totalPages;
-        private long totalElements;
-        private boolean isFirst;
-        private boolean isLast;
-
-        public static Pagination from(Page<?> page) {
-            return Pagination.builder()
-                    .currentPage(page.getNumber())
-                    .pageSize(page.getSize())
-                    .totalPages(page.getTotalPages())
-                    .totalElements(page.getTotalElements())
-                    .isFirst(page.isFirst())
-                    .isLast(page.isLast())
-                    .build();
-        }
-    }
 
     public static PagedUserResponse from(Page<UserResponse> page) {
         return PagedUserResponse.builder()

--- a/src/main/java/com/puzzlelog/api/repository/listsearch/DiaryListSearch.java
+++ b/src/main/java/com/puzzlelog/api/repository/listsearch/DiaryListSearch.java
@@ -1,0 +1,110 @@
+package com.puzzlelog.api.repository.listsearch;
+
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Component;
+
+import com.puzzlelog.api.dto.request.diary.meta.DiarySearchRequest;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+@Component
+public class DiaryListSearch implements ListSearch<DiarySearchRequest, Criteria> { // 일기 목록 조회
+
+    @Override
+    public Criteria buildSearch(DiarySearchRequest request) {
+        Criteria criteria = new Criteria();
+
+        if (request.getUserId() != null && !request.getUserId().trim().isEmpty()) {
+            criteria.and("userId").is(request.getUserId());
+        }
+
+        if (request.getTitle() != null && !request.getTitle().trim().isEmpty()) {
+            criteria.and("title").regex(".*" + request.getTitle() + ".*", "i");
+        }
+
+        if (request.getEmotionContentId() != null) {
+            criteria.and("emotionContentId").is(request.getEmotionContentId());
+        }
+
+        if (request.getBackgroundContentId() != null) {
+            criteria.and("backgroundContentId").is(request.getBackgroundContentId());
+        }
+
+        if (request.getIsShared() != null) {
+            criteria.and("isShared").is(request.getIsShared());
+        }
+
+        if (request.getIsDeleted() != null) {
+            criteria.and("isDeleted").is(request.getIsDeleted());
+        }
+
+        if (request.getOpenAt() != null) {
+            if (request.getOpenAt()) {
+                criteria.and("openAt").ne(null);
+            } else {
+                criteria.and("openAt").is(null);
+            }
+        }
+
+        if (request.getCreatedAt() != null) {
+            Instant fromInstant = request.getCreatedAt().atStartOfDay(ZoneOffset.UTC).toInstant();
+            Instant toInstant = request.getCreatedAt().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
+        } else if (request.getCreatedAtFrom() != null || request.getCreatedAtTo() != null) {
+            Instant fromInstant;
+            Instant toInstant;
+
+            if (request.getCreatedAtFrom() != null && request.getCreatedAtTo() != null) {
+                fromInstant = request.getCreatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant();
+                toInstant = request.getCreatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+                if (fromInstant.isAfter(toInstant)) {
+                    throw new IllegalArgumentException("createdAtFrom은 createdAtTo보다 이전 날짜여야 합니다.");
+                }
+            } else if (request.getCreatedAtFrom() != null) {
+                fromInstant = request.getCreatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant();
+                toInstant = Instant.now();
+            } else {
+                fromInstant = Instant.ofEpochSecond(0);
+                toInstant = request.getCreatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+            }
+
+            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
+        }
+
+        if (request.getUpdatedAtFrom() != null || request.getUpdatedAtTo() != null) {
+            Instant fromInstant;
+            Instant toInstant;
+
+            if (request.getUpdatedAtFrom() != null && request.getUpdatedAtTo() != null) {
+                fromInstant = request.getUpdatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant();
+                toInstant = request.getUpdatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+                if (fromInstant.isAfter(toInstant)) {
+                    throw new IllegalArgumentException("updatedAtFrom은 updatedAtTo보다 이전 날짜여야 합니다.");
+                }
+            } else if (request.getUpdatedAtFrom() != null) {
+                fromInstant = request.getUpdatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant();
+                toInstant = Instant.now();
+            } else {
+                fromInstant = Instant.ofEpochSecond(0);
+                toInstant = request.getUpdatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+            }
+
+            criteria.and("updatedAt").gte(fromInstant).lt(toInstant);
+        }
+
+        if (request.getToday() != null && request.getToday()) {
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            Instant fromInstant = today.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+            Instant toInstant = today.plusDays(1).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
+
+            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
+        }
+
+        return criteria;
+    }
+}

--- a/src/main/java/com/puzzlelog/api/repository/listsearch/ListSearch.java
+++ b/src/main/java/com/puzzlelog/api/repository/listsearch/ListSearch.java
@@ -1,0 +1,5 @@
+package com.puzzlelog.api.repository.listsearch;
+
+public interface ListSearch<T, R> {
+    R buildSearch(T request);
+}

--- a/src/main/java/com/puzzlelog/api/repository/listsearch/PieceListSearch.java
+++ b/src/main/java/com/puzzlelog/api/repository/listsearch/PieceListSearch.java
@@ -1,0 +1,65 @@
+package com.puzzlelog.api.repository.listsearch;
+
+import com.puzzlelog.api.dto.request.piece.PieceSearchRequest;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+@Component
+public class PieceListSearch implements ListSearch<PieceSearchRequest, Criteria> { // 조각 목록 조회
+
+    @Override
+    public Criteria buildSearch(PieceSearchRequest request) {
+        Criteria criteria = new Criteria();
+
+        if (request.getUserId() != null && !request.getUserId().trim().isEmpty()) {
+            criteria.and("userId").is(request.getUserId());
+        }
+
+        if (request.getType() != null) {
+            criteria.and("type").is(request.getType());
+        }
+
+        if (request.getContent() != null) {
+            criteria.and("content").regex(".*" + request.getContent() + ".*", "i");
+        }
+
+        if (request.getTags() != null && !request.getTags().isEmpty()) {
+            criteria.and("tags").in(request.getTags());
+        }
+
+        if (request.getIsPrivate() != null) {
+            criteria.and("isPrivate").is(request.getIsPrivate());
+        }
+
+        if (request.getIsDeleted() != null) {
+            criteria.and("isDeleted").is(request.getIsDeleted());
+        }
+
+        if (request.getCreatedAtFrom() != null || request.getCreatedAtTo() != null) {
+            Instant fromInstant;
+            Instant toInstant;
+
+            if (request.getCreatedAtFrom() != null && request.getCreatedAtTo() != null) {
+                fromInstant = request.getCreatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant();
+                toInstant = request.getCreatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+
+                if (fromInstant.isAfter(toInstant)) {
+                    throw new IllegalArgumentException("createdAtFrom 날짜는 createdAtTo 날짜보다 이전이어야 합니다.");
+                }
+            } else if (request.getCreatedAtFrom() != null) {
+                fromInstant = request.getCreatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant();
+                toInstant = Instant.now();
+            } else {
+                fromInstant = Instant.ofEpochSecond(0);
+                toInstant = request.getCreatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+            }
+
+            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
+        }
+
+        return criteria;
+    }
+}

--- a/src/main/java/com/puzzlelog/api/repository/listsearch/UserListSearch.java
+++ b/src/main/java/com/puzzlelog/api/repository/listsearch/UserListSearch.java
@@ -1,19 +1,21 @@
-package com.puzzlelog.api.repository.mysql;
-
-import com.puzzlelog.api.dao.entity.User;
-import com.puzzlelog.api.dto.request.user.UserSearchRequest;
-import org.springframework.data.jpa.domain.Specification;
+package com.puzzlelog.api.repository.listsearch;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-public class UserSpecifications {
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
 
-    // 조건별 동적 쿼리 생성 (Specification 조합)
-    public static Specification<User> withConditions(UserSearchRequest req) {
-        return Specification
-            .where(emailEquals(req.getEmail()))
+import com.puzzlelog.api.dao.entity.User;
+import com.puzzlelog.api.dto.request.user.UserSearchRequest;
+
+@Component
+public class UserListSearch implements ListSearch<UserSearchRequest, Specification<User>> { // 유저 목록 조회
+
+    @Override
+    public Specification<User> buildSearch(UserSearchRequest req) {
+        return Specification.where(emailEquals(req.getEmail()))
             .and(userIdEquals(req.getUserId()))
             .and(nicknameEquals(req.getNickname()))
             .and(createdAtBetween(req.getCreatedAtFrom(), req.getCreatedAtTo()))
@@ -25,56 +27,69 @@ public class UserSpecifications {
             .and(lastLoginBetween(req.getLastLoginFrom(), req.getLastLoginTo()));
     }
 
-    private static Specification<User> emailEquals(String email) {
+    private Specification<User> emailEquals(String email) {
         return (root, query, cb) -> email == null ? null : cb.equal(root.get("email"), email);
     }
 
-    private static Specification<User> userIdEquals(String userId) {
+    private Specification<User> userIdEquals(String userId) {
         return (root, query, cb) -> userId == null ? null : cb.equal(root.get("userId"), userId);
     }
 
-    private static Specification<User> nicknameEquals(String nickname) {
+    private Specification<User> nicknameEquals(String nickname) {
         return (root, query, cb) -> nickname == null ? null : cb.equal(root.get("nickname"), nickname);
     }
 
-    // 생성일자 범위로 조회
-    private static Specification<User> createdAtBetween(LocalDate from, LocalDate to) {
+    private Specification<User> createdAtBetween(LocalDate from, LocalDate to) {
         if (from == null && to == null) return null;
 
         LocalDateTime fromDate = from != null ? from.atStartOfDay() : LocalDateTime.MIN;
         LocalDateTime toDate = to != null ? to.atTime(LocalTime.MAX) : LocalDateTime.MAX;
+
+        if (fromDate.isAfter(toDate)) {
+            throw new IllegalArgumentException("createdAtFrom 날짜는 createdAtTo 날짜보다 이전이어야 합니다.");
+        }
 
         return (root, query, cb) -> cb.between(root.get("createdAt"), fromDate, toDate);
     }
 
-    // 생년월일 범위로 조회
-    private static Specification<User> birthDateBetween(LocalDate from, LocalDate to) {
+    private Specification<User> birthDateBetween(LocalDate from, LocalDate to) {
         if (from == null && to == null) return null;
-        return (root, query, cb) -> cb.between(root.get("birthDate"), from, to);
+
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new IllegalArgumentException("birthDateFrom 날짜는 birthDateTo 날짜보다 이전이어야 합니다.");
+        }
+
+        LocalDate fromDate = from != null ? from : LocalDate.of(1900, 1, 1);
+        LocalDate toDate = to != null ? to : LocalDate.now();
+
+        return (root, query, cb) -> cb.between(root.get("birthDate"), fromDate, toDate);
     }
 
-    private static Specification<User> genderEquals(String gender) {
+    private Specification<User> genderEquals(String gender) {
         return (root, query, cb) -> gender == null ? null : cb.equal(root.get("gender"), gender);
     }
 
-    private static Specification<User> isAlarmEquals(Boolean isAlarm) {
+    private Specification<User> isAlarmEquals(Boolean isAlarm) {
         return (root, query, cb) -> isAlarm == null ? null : cb.equal(root.get("isAlarm"), isAlarm);
     }
 
-    private static Specification<User> statusEquals(String status) {
+    private Specification<User> statusEquals(String status) {
         return (root, query, cb) -> status == null ? null : cb.equal(root.get("status"), status);
     }
 
-    private static Specification<User> roleEquals(String role) {
+    private Specification<User> roleEquals(String role) {
         return (root, query, cb) -> role == null ? null : cb.equal(root.get("role"), role);
     }
 
-    // 마지막 로그인 범위로 조회
-    private static Specification<User> lastLoginBetween(LocalDate from, LocalDate to) {
+    private Specification<User> lastLoginBetween(LocalDate from, LocalDate to) {
         if (from == null && to == null) return null;
 
         LocalDateTime fromDate = from != null ? from.atStartOfDay() : LocalDateTime.MIN;
         LocalDateTime toDate = to != null ? to.atTime(LocalTime.MAX) : LocalDateTime.MAX;
+
+        if (fromDate.isAfter(toDate)) {
+            throw new IllegalArgumentException("lastLoginFrom 날짜는 lastLoginTo 날짜보다 이전이어야 합니다.");
+        }
 
         return (root, query, cb) -> cb.between(root.get("lastLogin"), fromDate, toDate);
     }

--- a/src/main/java/com/puzzlelog/api/repository/mongo/AlbumRepository.java
+++ b/src/main/java/com/puzzlelog/api/repository/mongo/AlbumRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.puzzlelog.api.dao.document.Album;
 
-public interface AlbumRepository extends MongoRepository<Album, ObjectId> {
+public interface AlbumRepository extends MongoRepository<Album, String> {
     List<Album> findByUserId(String userId); // 특정 사용자의 앨범만 조회
 
     // ✅ ObjectId를 사용하여 앨범 조회

--- a/src/main/java/com/puzzlelog/api/repository/mongo/DiaryElementRepository.java
+++ b/src/main/java/com/puzzlelog/api/repository/mongo/DiaryElementRepository.java
@@ -1,14 +1,22 @@
 package com.puzzlelog.api.repository.mongo;
 
-import java.util.List;
-
-import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.Optional;
 
 import com.puzzlelog.api.dao.document.DiaryElement;
 
 @Repository
-public interface DiaryElementRepository extends MongoRepository<DiaryElement, ObjectId> {
-	List<DiaryElement> findAllByDiaryIdOrderByElementOrderAsc(String diaryId);
+public interface DiaryElementRepository extends MongoRepository<DiaryElement, String> {
+
+    List<DiaryElement> findAllByDiaryIdAndIsDeletedFalse(String diaryId);
+
+    Page<DiaryElement> findAllByDiaryIdAndIsDeletedFalse(String diaryId, Pageable pageable);
+
+    Page<DiaryElement> findAllByDiaryIdAndElementTypeAndIsDeletedFalse(String diaryId, String elementType, Pageable pageable);
+
+    Optional<DiaryElement> findByIdAndIsDeletedFalse(String id);
 }

--- a/src/main/java/com/puzzlelog/api/repository/mongo/PieceRepository.java
+++ b/src/main/java/com/puzzlelog/api/repository/mongo/PieceRepository.java
@@ -21,4 +21,7 @@ public interface PieceRepository extends MongoRepository<Piece, String> {
     // 페이징 처리 가능
     Page<Piece> findByUserIdAndIsDeletedFalse(Integer userId, Pageable pageable);
     Page<Piece> findByIsDeletedFalse(Pageable pageable);
+    
+    // 컨텐츠 타입 조회
+    boolean existsByIdAndTypeAndIsDeletedFalse(String id, String type);
 }

--- a/src/main/java/com/puzzlelog/api/service/DiaryElementService.java
+++ b/src/main/java/com/puzzlelog/api/service/DiaryElementService.java
@@ -1,0 +1,257 @@
+package com.puzzlelog.api.service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.puzzlelog.api.dao.document.Diary;
+import com.puzzlelog.api.dao.document.DiaryElement;
+import com.puzzlelog.api.dao.document.ElementDecoration;
+import com.puzzlelog.api.dao.document.Piece;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementRequest;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementSearchRequest;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementUpdateRequest;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementDeleteResponse;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementResponse;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementUpdateResponse;
+import com.puzzlelog.api.dto.response.diary.element.PagedDiaryElementResponse;
+import com.puzzlelog.api.repository.mongo.DiaryElementRepository;
+import com.puzzlelog.api.repository.mongo.DiaryRepository;
+import com.puzzlelog.api.repository.mongo.PieceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryElementService {
+	
+	private final DiaryRepository diaryRepository;
+	private final  DiaryElementRepository diaryElementRepository;
+	private final PieceRepository pieceRepository;
+
+	// 요소 생성
+	@Transactional
+	public DiaryElementResponse createDiaryElement(String diaryId, DiaryElementRequest request) {
+
+	    Diary diary = diaryRepository.findById(diaryId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+	    if (Boolean.TRUE.equals(diary.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 일기입니다.");
+	    }
+
+	    if (!request.isValidByType()) {
+	        throw new IllegalArgumentException("요소 타입과 contentId/drawingData 정보가 올바르지 않습니다.");
+	    }
+
+	    DiaryElement element = DiaryElement.builder()
+	        .diaryId(diaryId)
+	        .elementType(request.getElementType())
+	        .contentId(request.getContentId())
+	        .drawingData(request.getDrawingData())
+	        .position(request.getPosition())
+	        .scale(request.getScale())
+	        .rotation(request.getRotation())
+	        .createdAt(Instant.now())
+	        .updatedAt(Instant.now())
+	        .isDeleted(false)
+	        // decoration 등 추가 로직 위치
+	        .build();
+
+	    diaryElementRepository.save(element);
+
+	    // 생성된 요소를 일기에도 추가
+	    List<String> updatedElementIds = new ArrayList<>(diary.getElementIds());
+	    updatedElementIds.add(element.getId());
+
+	    diary.setElementIds(updatedElementIds);
+	    diary.setUpdatedAt(Instant.now());
+	    diaryRepository.save(diary);
+
+	    return DiaryElementResponse.from(element);
+	}
+	
+	// 단일 요소 조회
+	@Transactional(readOnly = true)
+	public DiaryElementResponse getElement(String diaryId, String elementId) {
+	    Diary diary = diaryRepository.findById(diaryId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+	    if (Boolean.TRUE.equals(diary.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 일기입니다.");
+	    }
+
+	    DiaryElement element = diaryElementRepository.findByIdAndIsDeletedFalse(elementId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 요소입니다."));
+
+	    return DiaryElementResponse.from(element);
+	}
+	
+	// 요소 목록 조회
+	@Transactional(readOnly = true)
+	public PagedDiaryElementResponse getElements(String diaryId, DiaryElementSearchRequest request) {
+	    Diary diary = diaryRepository.findById(diaryId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+	    if (Boolean.TRUE.equals(diary.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 일기입니다.");
+	    }
+
+	    final List<String> allowedTypes = List.of("TEXT", "IMAGE", "AUDIO", "VIDEO", "STICKER", "DRAWING");
+	    if (request.getElementType() != null && !request.getElementType().isBlank()) {
+	        if (!allowedTypes.contains(request.getElementType())) {
+	            throw new IllegalArgumentException("잘못된 요소 타입입니다: " + request.getElementType());
+	        }
+	    }
+
+	    Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
+	    Page<DiaryElement> elementPage;
+
+	    if (request.getElementType() != null && !request.getElementType().isBlank()) {
+	        elementPage = diaryElementRepository.findAllByDiaryIdAndElementTypeAndIsDeletedFalse(diaryId, request.getElementType(), pageable);
+	    } else {
+	        elementPage = diaryElementRepository.findAllByDiaryIdAndIsDeletedFalse(diaryId, pageable);
+	    }
+
+	    return PagedDiaryElementResponse.of(
+	        elementPage.getContent(),
+	        request.getPage(),
+	        request.getSize(),
+	        elementPage.getTotalElements()
+	    );
+	}
+	
+	// 요소 수정
+	@Transactional
+	public DiaryElementUpdateResponse updateDiaryElement(String diaryId, String elementId, DiaryElementUpdateRequest request) {
+	    Diary diary = diaryRepository.findById(diaryId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+	    if (Boolean.TRUE.equals(diary.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 일기입니다.");
+	    }
+
+	    DiaryElement element = diaryElementRepository.findById(elementId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 요소입니다."));
+
+	    if (Boolean.TRUE.equals(element.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 요소입니다.");
+	    }
+
+	    Map<String, DiaryElementUpdateResponse.UpdateField> updatedFields = new HashMap<>();
+
+	    if (request.getContentId() != null && !request.getContentId().isBlank()
+	        && !request.getContentId().equals(element.getContentId())) {
+
+	        String elementType = element.getElementType();
+
+	        if ("DRAWING".equals(elementType)) {
+	            throw new IllegalArgumentException("DRAWING 타입 요소는 contentId를 변경할 수 없습니다.");
+	        }
+
+	        Piece piece = pieceRepository.findById(request.getContentId())
+	            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 콘텐츠입니다."));
+
+	        if (!elementType.equals(piece.getType())) {
+	            throw new IllegalArgumentException("요소 타입과 콘텐츠 타입이 일치하지 않습니다.");
+	        }
+
+	        updatedFields.put("contentId", new DiaryElementUpdateResponse.UpdateField(element.getContentId(), request.getContentId()));
+	        element.setContentId(request.getContentId());
+	    }
+
+	    if (request.getDrawingData() != null 
+	        && !request.getDrawingData().equals(element.getDrawingData())) {
+	        if (!"DRAWING".equals(element.getElementType())) {
+	            throw new IllegalArgumentException("DRAWING 타입이 아닌 요소는 drawingData를 지정할 수 없습니다.");
+	        }
+
+	        updatedFields.put("drawingData", new DiaryElementUpdateResponse.UpdateField(element.getDrawingData(), request.getDrawingData()));
+	        element.setDrawingData(request.getDrawingData());
+	    }
+
+	    if (request.getPosition() != null 
+	        && !request.getPosition().equals(element.getPosition())) {
+	        updatedFields.put("position", new DiaryElementUpdateResponse.UpdateField(element.getPosition(), request.getPosition()));
+	        element.setPosition(request.getPosition());
+	    }
+
+	    if (request.getScale() != null 
+	        && !request.getScale().equals(element.getScale())) {
+	        updatedFields.put("scale", new DiaryElementUpdateResponse.UpdateField(element.getScale(), request.getScale()));
+	        element.setScale(request.getScale());
+	    }
+
+	    if (request.getRotation() != null 
+	        && !request.getRotation().equals(element.getRotation())) {
+	        updatedFields.put("rotation", new DiaryElementUpdateResponse.UpdateField(element.getRotation(), request.getRotation()));
+	        element.setRotation(request.getRotation());
+	    }
+
+	    if (request.getDecoration() != null) {
+	        ElementDecoration newDecoration = ElementDecoration.from(request.getDecoration());
+	        if (!newDecoration.equals(element.getDecoration())) {
+	            updatedFields.put("decoration", new DiaryElementUpdateResponse.UpdateField(element.getDecoration(), newDecoration));
+	            element.setDecoration(newDecoration);
+	        }
+	    }
+
+	    if (updatedFields.isEmpty()) {
+	        throw new IllegalArgumentException("변경된 내용이 없습니다.");
+	    }
+
+	    element.setUpdatedAt(Instant.now());
+	    diaryElementRepository.save(element);
+
+	    return DiaryElementUpdateResponse.builder()
+	        .elementId(elementId)
+	        .updatedFields(updatedFields)
+	        .build();
+	}
+	
+	// 요소 삭제
+	@Transactional
+	public DiaryElementDeleteResponse deleteDiaryElement(String diaryId, String elementId) {
+	    Diary diary = diaryRepository.findById(diaryId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+	    if (Boolean.TRUE.equals(diary.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 일기입니다.");
+	    }
+
+	    DiaryElement element = diaryElementRepository.findById(elementId)
+	        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 요소입니다."));
+
+	    if (Boolean.TRUE.equals(element.getIsDeleted())) {
+	        throw new NoSuchElementException("존재하지 않는 요소입니다.");
+	    }
+
+	    // 요소 논리 삭제 처리
+	    element.setIsDeleted(true);
+	    element.setUpdatedAt(Instant.now());
+	    diaryElementRepository.save(element);
+
+	    // 일기의 요소 목록에서도 제거
+	    List<String> elementIds = diary.getElementIds().stream()
+	        .filter(id -> !id.equals(elementId))
+	        .collect(Collectors.toList());
+
+	    diary.setElementIds(elementIds);
+	    diary.setUpdatedAt(Instant.now());
+	    diaryRepository.save(diary);
+
+	    return DiaryElementDeleteResponse.of(diaryId, elementId);
+	}
+
+}

--- a/src/main/java/com/puzzlelog/api/service/DiaryService.java
+++ b/src/main/java/com/puzzlelog/api/service/DiaryService.java
@@ -3,28 +3,36 @@ package com.puzzlelog.api.service;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.puzzlelog.api.dao.document.Diary;
 import com.puzzlelog.api.dao.document.DiaryElement;
-import com.puzzlelog.api.dto.request.diary.DiaryRequest;
-import com.puzzlelog.api.dto.request.diary.DiarySearchRequest;
-import com.puzzlelog.api.dto.response.diary.DiaryDetailResponse;
-import com.puzzlelog.api.dto.response.diary.DiaryResponse;
-import com.puzzlelog.api.dto.response.diary.PagedDiaryResponse;
+import com.puzzlelog.api.dto.request.diary.element.DiaryElementsOrderUpdateRequest;
+import com.puzzlelog.api.dto.request.diary.meta.DiaryMetaUpdateRequest;
+import com.puzzlelog.api.dto.request.diary.meta.DiaryRequest;
+import com.puzzlelog.api.dto.request.diary.meta.DiarySearchRequest;
+import com.puzzlelog.api.dto.response.diary.element.DiaryElementsOrderResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryDeleteResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryDetailResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryMetaUpdateResponse;
+import com.puzzlelog.api.dto.response.diary.meta.DiaryResponse;
+import com.puzzlelog.api.dto.response.diary.meta.PagedDiaryResponse;
+import com.puzzlelog.api.repository.listsearch.DiaryListSearch;
 import com.puzzlelog.api.repository.mongo.DiaryElementRepository;
 import com.puzzlelog.api.repository.mongo.DiaryRepository;
 
@@ -37,6 +45,7 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final DiaryElementRepository diaryElementRepository;
     private final MongoTemplate mongoTemplate;
+    private final DiaryListSearch diaryListSearch;
 
     // 일기 생성
     @Transactional
@@ -70,56 +79,41 @@ public class DiaryService {
 
         diaryRepository.save(diary);
         
-        // [유효성 검사] 요소 타입과 contentId/drawingData 검증
+        // [유효성 검사] 요소 타입과 contentId/drawingData 검증 (간결화 버전)
         final List<String> allowedTypes = List.of("TEXT", "IMAGE", "AUDIO", "VIDEO", "STICKER", "DRAWING");
 
         request.getElements().forEach(elementRequest -> {
-            String elementType = elementRequest.getElementType();
-
-            // elementType이 허용된 타입인지 검사
-            if (!allowedTypes.contains(elementType)) {
-                throw new IllegalArgumentException("허용되지 않는 요소 타입입니다: " + elementType);
+            if (!allowedTypes.contains(elementRequest.getElementType())) {
+                throw new IllegalArgumentException("허용되지 않는 요소 타입입니다: " + elementRequest.getElementType());
             }
-            
-            if ("DRAWING".equals(elementType)) {
-                // DRAWING 타입은 drawingData 필수, contentId 지정 불가
-                if (elementRequest.getDrawingData() == null || elementRequest.getDrawingData().isBlank()) {
-                    throw new IllegalArgumentException("DRAWING 타입의 요소는 drawingData가 필수입니다.");
-                }
-                if (elementRequest.getContentId() != null && !elementRequest.getContentId().isBlank()) {
-                    throw new IllegalArgumentException("DRAWING 타입의 요소는 contentId를 지정할 수 없습니다.");
-                }
-            } else {
-                // DRAWING이 아닌 타입은 contentId 필수, drawingData 지정 불가
-                if (elementRequest.getContentId() == null || elementRequest.getContentId().isBlank()) {
-                    throw new IllegalArgumentException("DRAWING 타입이 아닌 요소는 contentId가 필수입니다.");
-                }
-                if (elementRequest.getDrawingData() != null && !elementRequest.getDrawingData().isBlank()) {
-                    throw new IllegalArgumentException("DRAWING 타입이 아닌 요소는 drawingData를 지정할 수 없습니다.");
-                }
+            if (!elementRequest.isValidByType()) {
+                throw new IllegalArgumentException("요소 타입과 contentId 또는 drawingData가 올바르지 않습니다: " 
+                                                   + elementRequest.getElementType());
             }
         });
 
         // [요소 생성] DiaryElement 객체 생성 및 저장 후 Element ID 리스트 반환
         List<String> savedElementIds = request.getElements().stream()
+            .peek(elementRequest -> {
+                if (!elementRequest.isValidByType()) {
+                    throw new IllegalArgumentException("요소 타입과 contentId 또는 drawingData가 올바르지 않습니다: " + elementRequest.getElementType());
+                }
+            })
             .map(elementRequest -> {
-            	DiaryElement element = DiaryElement.builder()
-            		    .diaryId(diary.getId())
-            		    .elementType(elementRequest.getElementType())
-            		    .contentId(elementRequest.getContentId())
-            		    .drawingData(elementRequest.getDrawingData())
-            		    .elementOrder(elementRequest.getElementOrder())
-            		    .position(Optional.ofNullable(elementRequest.getPosition()).orElse(List.of(0.0, 0.0)))
-            		    .scale(Optional.ofNullable(elementRequest.getScale()).orElse(1.0))
-            		    .rotation(Optional.ofNullable(elementRequest.getRotation()).orElse(0.0))
-            		    .createdAt(Instant.now())
-            		    .updatedAt(Instant.now())
-            		    // TODO: 추후 요소 편집 정보(ElementDecoration) 붙일 위치
-            		    // .decoration(elementRequest.getDecoration())
-            		    .build();  // ✅ 빌더 호출 종료를 명확히 함
+                DiaryElement element = DiaryElement.builder()
+                        .diaryId(diary.getId())
+                        .elementType(elementRequest.getElementType())
+                        .contentId(elementRequest.getContentId())
+                        .drawingData(elementRequest.getDrawingData())
+                        .position(Optional.ofNullable(elementRequest.getPosition()).orElse(List.of(0.0, 0.0)))
+                        .scale(Optional.ofNullable(elementRequest.getScale()).orElse(1.0))
+                        .rotation(Optional.ofNullable(elementRequest.getRotation()).orElse(0.0))
+                        .createdAt(Instant.now())
+                        .updatedAt(Instant.now())
+                        .build();
 
                 diaryElementRepository.save(element);
-                return element.getElementId();
+                return element.getId(); // ✅ 여기 변경!
             })
             .collect(Collectors.toList());
 
@@ -135,98 +129,143 @@ public class DiaryService {
         Diary diary = diaryRepository.findById(diaryId)
             .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
 
-        List<DiaryElement> elements = diaryElementRepository.findAllByDiaryIdOrderByElementOrderAsc(diaryId);
+        List<DiaryElement> elements = diaryElementRepository.findAllByDiaryIdAndIsDeletedFalse(diaryId);
 
-        return DiaryDetailResponse.from(diary, elements);
+        // diary.elementIds의 순서대로 elements 정렬
+        Map<String, DiaryElement> elementMap = elements.stream()
+            .collect(Collectors.toMap(DiaryElement::getId, e -> e)); // ✅ getId()로 변경
+
+        List<DiaryElement> sortedElements = diary.getElementIds().stream()
+            .map(elementMap::get)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+        return DiaryDetailResponse.from(diary, sortedElements);
     }
     
-    // 일기 목록 조회
-    @Transactional(readOnly = true)
-    public PagedDiaryResponse getDiaries(DiarySearchRequest request, int page, int size) {
 
-        Criteria criteria = new Criteria();
+	 // 일기 목록 조회 (현재 그대로 유지 가능)
+	 @Transactional(readOnly = true)
+	 public PagedDiaryResponse getDiaries(DiarySearchRequest request, int page, int size) {
+	     Criteria criteria = diaryListSearch.buildSearch(request);
+	     Query query = new Query(criteria)
+	         .with(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+	
+	     List<Diary> diaries = mongoTemplate.find(query, Diary.class);
+	     long total = mongoTemplate.count(Query.of(query).limit(-1).skip(-1), Diary.class);
+	
+	     return PagedDiaryResponse.of(diaries, page, size, total);
+	 }
+    
+    // 일기 메타 수정
+    @Transactional
+    public DiaryMetaUpdateResponse updateDiaryMeta(String diaryId, DiaryMetaUpdateRequest request) {
+        Diary diary = diaryRepository.findById(diaryId)
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 일기입니다."));
 
-        if (request.getUserId() != null && !request.getUserId().trim().isEmpty()) {
-            criteria.and("userId").is(request.getUserId());
+        Map<String, DiaryMetaUpdateResponse.UpdateField> updatedFields = new HashMap<>();
+
+        if (request.getTitle() != null && !request.getTitle().equals(diary.getTitle())) {
+            updatedFields.put("title", new DiaryMetaUpdateResponse.UpdateField(diary.getTitle(), request.getTitle()));
+            diary.setTitle(request.getTitle());
         }
 
-        if (request.getTitle() != null && !request.getTitle().trim().isEmpty()) {
-            criteria.and("title").regex(".*" + request.getTitle() + ".*", "i");
+        if (request.getBackgroundContentId() != null && !request.getBackgroundContentId().equals(diary.getBackgroundContentId())) {
+            updatedFields.put("backgroundContentId", new DiaryMetaUpdateResponse.UpdateField(diary.getBackgroundContentId(), request.getBackgroundContentId()));
+            diary.setBackgroundContentId(request.getBackgroundContentId());
         }
 
-        if (request.getEmotionContentId() != null) {
-            criteria.and("emotionContentId").is(request.getEmotionContentId());
+        if (request.getThemeColor() != null && !request.getThemeColor().equals(diary.getThemeColor())) {
+            updatedFields.put("themeColor", new DiaryMetaUpdateResponse.UpdateField(diary.getThemeColor(), request.getThemeColor()));
+            diary.setThemeColor(request.getThemeColor());
         }
 
-        if (request.getBackgroundContentId() != null) {
-            criteria.and("backgroundContentId").is(request.getBackgroundContentId());
+        if (request.getEmotionContentId() != null && !request.getEmotionContentId().equals(diary.getEmotionContentId())) {
+            updatedFields.put("emotionContentId", new DiaryMetaUpdateResponse.UpdateField(diary.getEmotionContentId(), request.getEmotionContentId()));
+            diary.setEmotionContentId(request.getEmotionContentId());
         }
 
-        if (request.getIsShared() != null) {
-            criteria.and("isShared").is(request.getIsShared());
+        if (request.getIsShared() != null && !request.getIsShared().equals(diary.getIsShared())) {
+            updatedFields.put("isShared", new DiaryMetaUpdateResponse.UpdateField(diary.getIsShared(), request.getIsShared()));
+            diary.setIsShared(request.getIsShared());
         }
 
-        if (request.getIsDeleted() != null) {
-            criteria.and("isDeleted").is(request.getIsDeleted());
+        if (request.getOpenAt() != null && !request.getOpenAt().equals(diary.getOpenAt())) {
+            updatedFields.put("openAt", new DiaryMetaUpdateResponse.UpdateField(diary.getOpenAt(), request.getOpenAt()));
+            diary.setOpenAt(request.getOpenAt());
         }
 
-        // openAt 여부에 따라 타임캡슐 필터링
-        if (request.getOpenAt() != null) {
-            if (request.getOpenAt()) {
-                criteria.and("openAt").ne(null);
-            } else {
-                criteria.and("openAt").is(null);
-            }
+        if (updatedFields.isEmpty()) {
+            throw new RuntimeException("수정된 내용이 없습니다.");
         }
 
-        // createdAt 날짜 필터
-        if (request.getCreatedAt() != null) {
-            Instant fromInstant = request.getCreatedAt().atStartOfDay(ZoneOffset.UTC).toInstant();
-            Instant toInstant = request.getCreatedAt().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
-            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
-        } else {
-            if (request.getCreatedAtFrom() != null || request.getCreatedAtTo() != null) {
-                Instant fromInstant = request.getCreatedAtFrom() != null
-                    ? request.getCreatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant()
-                    : Instant.ofEpochSecond(0);
+        diary.setUpdatedAt(Instant.now());
+        updatedFields.put("updatedAt", new DiaryMetaUpdateResponse.UpdateField(null, diary.getUpdatedAt()));
 
-                Instant toInstant = request.getCreatedAtTo() != null
-                    ? request.getCreatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
-                    : Instant.now();
+        diaryRepository.save(diary);
 
-                criteria.and("createdAt").gte(fromInstant).lt(toInstant);
-            }
-        }
-
-        // updatedAt 날짜 필터
-        if (request.getUpdatedAtFrom() != null || request.getUpdatedAtTo() != null) {
-            Instant fromInstant = request.getUpdatedAtFrom() != null
-                ? request.getUpdatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant()
-                : Instant.ofEpochSecond(0);
-
-            Instant toInstant = request.getUpdatedAtTo() != null
-                ? request.getUpdatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
-                : Instant.now();
-
-            criteria.and("updatedAt").gte(fromInstant).lt(toInstant);
-        }
-
-        // 오늘 생성된 일기만 조회 (today=true일 때)
-        if (request.getToday() != null && request.getToday()) {
-            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-            Instant fromInstant = today.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
-            Instant toInstant = today.plusDays(1).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
-
-            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
-        }
-
-        Query query = new Query(criteria)
-            .with(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
-
-        List<Diary> diaries = mongoTemplate.find(query, Diary.class);
-        long total = mongoTemplate.count(Query.of(query).limit(-1).skip(-1), Diary.class);
-
-        return PagedDiaryResponse.of(diaries, page, size, total);
+        return DiaryMetaUpdateResponse.builder()
+            .diaryId(diaryId)
+            .updatedFields(updatedFields)
+            .build();
     }
     
+    // 일기 요소 순서 변경
+    @Transactional
+    public DiaryElementsOrderResponse updateDiaryElements(String diaryId, DiaryElementsOrderUpdateRequest request) {
+        Diary diary = diaryRepository.findById(diaryId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+        List<String> requestedElementIds = request.getElementIds();
+
+        if (requestedElementIds == null || requestedElementIds.isEmpty()) {
+            throw new IllegalArgumentException("요소 목록이 비어있습니다.");
+        }
+
+        if (requestedElementIds.size() == 1) {
+            throw new IllegalArgumentException("요소가 1개뿐이므로 순서를 변경할 수 없습니다.");
+        }
+
+        if (Objects.equals(diary.getElementIds(), requestedElementIds)) {
+            throw new IllegalArgumentException("요소들의 순서가 변경되지 않았습니다.");
+        }
+
+        // Iterable을 List로 변환
+        List<DiaryElement> elements = new ArrayList<>();
+        diaryElementRepository.findAllById(requestedElementIds).forEach(elements::add);
+
+        if (elements.size() != requestedElementIds.size()) {
+            throw new IllegalArgumentException("요청한 요소 중 일부가 존재하지 않습니다.");
+        }
+
+        diary.setElementIds(requestedElementIds);
+        diary.setUpdatedAt(Instant.now());
+
+        diaryRepository.save(diary);
+
+        return DiaryElementsOrderResponse.of(
+            diary.getId(),
+            diary.getElementIds(),
+            diary.getUpdatedAt()
+        );
+    }
+
+    
+    // 일기 논리적 삭제
+    @Transactional
+    public DiaryDeleteResponse deleteDiary(String diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 일기입니다."));
+
+        if (Boolean.TRUE.equals(diary.getIsDeleted())) {
+            throw new NoSuchElementException("존재하지 않는 일기입니다.");
+        }
+
+        diary.setIsDeleted(true);
+        diary.setUpdatedAt(Instant.now());
+
+        diaryRepository.save(diary);
+
+        return DiaryDeleteResponse.of(diary.getId(), diary.getUserId());
+    }
 }

--- a/src/main/java/com/puzzlelog/api/service/PieceService.java
+++ b/src/main/java/com/puzzlelog/api/service/PieceService.java
@@ -2,7 +2,6 @@ package com.puzzlelog.api.service;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +27,14 @@ import com.puzzlelog.api.dto.response.piece.PagedPieceResponse;
 import com.puzzlelog.api.dto.response.piece.PieceDeleteResponse;
 import com.puzzlelog.api.dto.response.piece.PieceResponse;
 import com.puzzlelog.api.dto.response.piece.PieceUpdateResponse;
+import com.puzzlelog.api.repository.listsearch.PieceListSearch;
 import com.puzzlelog.api.repository.mongo.PieceRepository;
 import com.puzzlelog.api.repository.mysql.UserRepository;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class PieceService {
 
 	private static final Logger logger = LoggerFactory.getLogger(PieceService.class);
@@ -40,25 +43,20 @@ public class PieceService {
     private final UserRepository userRepository;
     private final MongoTemplate mongoTemplate;
     private final CloudinaryService cloudinaryService;
-
-    public PieceService(PieceRepository pieceRepository, UserRepository userRepository, 
-    		MongoTemplate mongoTemplate, CloudinaryService cloudinaryService) {
-        this.pieceRepository = pieceRepository;
-        this.userRepository = userRepository;
-        this.mongoTemplate = mongoTemplate;
-        this.cloudinaryService = cloudinaryService;
-    }
+    private final PieceListSearch pieceListSearch;
 
     // 조각 추가 메서드 (완전한 형태)
     public PieceResponse addPiece(PieceRequest request, MultipartFile file) {
-    	
+        
         if (request.getUserId() == null || request.getUserId().trim().isEmpty()) {
             throw new RuntimeException("사용자 ID는 필수입니다.");
         }
-        if (request.getType() == null) {
+        
+        if (request.getType() == null || request.getType().trim().isEmpty()) {
             throw new RuntimeException("타입은 필수입니다.");
         }
-        if (request.getType() == Piece.Type.TEXT && (request.getContent() == null || request.getContent().trim().isEmpty())) {
+        
+        if ("TEXT".equals(request.getType()) && (request.getContent() == null || request.getContent().trim().isEmpty())) {
             throw new RuntimeException("텍스트 타입의 경우 내용(content)은 필수입니다.");
         }
 
@@ -66,16 +64,17 @@ public class PieceService {
         User user = userRepository.findByUserId(request.getUserId())
             .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다."));
 
-        if (user.getStatus() == User.Status.BANNED) {
+        if ("BANNED".equals(user.getStatus())) {
             throw new RuntimeException("차단된 사용자는 조각을 추가할 수 없습니다.");
         }
-        if (user.getStatus() == User.Status.DELETED) {
+        
+        if ("DELETED".equals(user.getStatus())) {
             throw new RuntimeException("존재하지 않는 사용자입니다.");
         }
 
-        if (!"TEXT".equals(request.getType()) && file == null) {
-    	    throw new RuntimeException("TEXT 이외의 타입은 파일이 반드시 포함되어야 합니다.");
-    	}
+        if (!"TEXT".equals(request.getType()) && (file == null || file.isEmpty())) {
+            throw new RuntimeException("TEXT 이외의 타입은 파일이 반드시 포함되어야 합니다.");
+        }
 
         String mediaId = null;
         String publicId = null;
@@ -142,49 +141,9 @@ public class PieceService {
     // 목록 조회 메서드 (페이징 포함)
     @Transactional(readOnly = true)
     public PagedPieceResponse searchPieces(PieceSearchRequest request, int page, int size) {
-        request.applyDateFilters();
-
-        Criteria criteria = new Criteria();
-
-        if (request.getUserId() != null && !request.getUserId().trim().isEmpty()) {
-            criteria.and("userId").is(request.getUserId());
-        }
-
-        if (request.getType() != null) {
-            criteria.and("type").is(request.getType());
-        }
-
-        if (request.getContent() != null) {
-            criteria.and("content").regex(".*" + request.getContent() + ".*", "i");
-        }
-
-        if (request.getTags() != null && !request.getTags().isEmpty()) {
-            criteria.and("tags").in(request.getTags());
-        }
-
-        if (request.getIsPrivate() != null) {
-            criteria.and("isPrivate").is(request.getIsPrivate());
-        }
-
-        if (request.getIsDeleted() != null) {
-            criteria.and("isDeleted").is(request.getIsDeleted());
-        }
-
-        // 날짜 필터 처리 (LocalDate → Instant 변환 명확히)
-        if (request.getCreatedAtFrom() != null || request.getCreatedAtTo() != null) {
-            Instant fromInstant = request.getCreatedAtFrom() != null
-                ? request.getCreatedAtFrom().atStartOfDay(ZoneOffset.UTC).toInstant()
-                : Instant.ofEpochSecond(0);
-
-            Instant toInstant = request.getCreatedAtTo() != null
-                ? request.getCreatedAtTo().plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()
-                : Instant.now();
-
-            criteria.and("createdAt").gte(fromInstant).lt(toInstant);
-        }
-
+        Criteria criteria = pieceListSearch.buildSearch(request);
         Query query = new Query(criteria)
-            .with(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
+                        .with(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
 
         List<Piece> pieces = mongoTemplate.find(query, Piece.class);
         long total = mongoTemplate.count(Query.of(query).limit(-1).skip(-1), Piece.class);
@@ -307,11 +266,11 @@ public class PieceService {
     @Transactional
     public PieceDeleteResponse deletePiece(String pieceId) {
         Piece piece = pieceRepository.findById(pieceId)
-            .orElseThrow(() -> new RuntimeException("조각을 찾을 수 없습니다."));
+            .orElseThrow(() -> new RuntimeException("존재하지 않는 조각입니다."));
 
         // 이미 삭제된 경우 처리
         if (piece.getIsDeleted()) {
-            throw new RuntimeException("이미 삭제된 조각입니다.");
+            throw new RuntimeException("존재하지 않는 조각입니다.");
         }
 
         piece.setIsDeleted(true);  // 삭제 처리

--- a/src/main/java/com/puzzlelog/api/service/UserService.java
+++ b/src/main/java/com/puzzlelog/api/service/UserService.java
@@ -25,11 +25,14 @@ import com.puzzlelog.api.dto.request.user.UserUpdateRequest;
 import com.puzzlelog.api.dto.response.piece.CloudinaryUploadResponse;
 import com.puzzlelog.api.dto.response.user.UserResponse;
 import com.puzzlelog.api.dto.response.user.UserUpdateResponse;
+import com.puzzlelog.api.repository.listsearch.UserListSearch;
 import com.puzzlelog.api.repository.mongo.UserHistoryRepository;
 import com.puzzlelog.api.repository.mysql.UserRepository;
-import com.puzzlelog.api.repository.mysql.UserSpecifications;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(UserService.class);
@@ -37,17 +40,9 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final CloudinaryService cloudinaryService;
+    
+    private final UserListSearch userListSearch;
     private final UserHistoryRepository userHistoryRepository;
-
-    public UserService(UserRepository userRepository, 
-            PasswordEncoder passwordEncoder,
-            CloudinaryService cloudinaryService,
-            UserHistoryRepository userHistoryRepository) {
-		this.userRepository = userRepository;
-		this.passwordEncoder = passwordEncoder;
-		this.cloudinaryService = cloudinaryService;
-		this.userHistoryRepository = userHistoryRepository;
-	}
 
     // 전체 사용자 조회 (페이징)
     @Transactional(readOnly = true)
@@ -60,9 +55,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public Page<UserResponse> findUsers(UserSearchRequest request, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-
-        Specification<User> specs = UserSpecifications.withConditions(request);
-
+        Specification<User> specs = userListSearch.buildSearch(request);
         return userRepository.findAll(specs, pageable).map(UserResponse::from);
     }
     


### PR DESCRIPTION
- 작업 내용
1. 일기의 API 생성 (일기 생성, 상세 조회, 메타정보 조회, 메타 정보 수정, 요소 순서 변경, 일기 삭제)
2. 일기의 요소의 API 생성 (요소 생성, 개별 조회, 목록 조회, 요소 수정, 요소 삭제)
3. 요소의 데코레이션(꾸미기) 기능 간단한 구성

- 기타 구성
○ Pagination 따로 분리
○ ApiResponse 위치 config에서 common으로 이동